### PR TITLE
Design: 버튼 공통 컴포넌트 UI 구현

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "semi": false,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "lint-staged": "^15.2.7",
         "postcss": "^8",
         "prettier": "^3.3.3",
+        "prettier-plugin-tailwindcss": "^0.6.5",
         "storybook": "^8.2.5",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -13609,6 +13610,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13629,6 +13631,81 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.5.tgz",
+      "integrity": "sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig-melody": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig-melody": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-error": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lint-staged": "^15.2.7",
     "postcss": "^8",
     "prettier": "^3.3.3",
+    "prettier-plugin-tailwindcss": "^0.6.5",
     "storybook": "^8.2.5",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable react/function-component-definition */
+
+interface ButtonProps {
+  disabled?: boolean
+  type: 'button' | 'submit' | 'reset' | undefined
+  className?: string
+  backgroundColor: string
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xlg'
+  children: string
+}
+
+const Button = ({
+  disabled = false,
+  type = 'button',
+  className,
+  backgroundColor = 'black',
+  size,
+  children,
+}: ButtonProps) => {
+  const baseStyle = 'text-lg-bold w-350 h-48 rounded-6'
+  const disabledStyle = 'bg-gray-600 cursor-not-allowed text-white'
+  const backgroundStyle =
+    backgroundColor === 'black'
+      ? 'bg-black-100 text-white'
+      : 'bg-white text-black-100 border border-black-100'
+
+  let variantStyle = ''
+  switch (size) {
+    case 'xs':
+      variantStyle = 'font-bold leading-6 text-sm w-95 h-35'
+      break
+    case 'sm':
+      variantStyle = 'text-md-bold w-108 h-38'
+      break
+    case 'md':
+      variantStyle = 'text-lg-bold w-144 h-48'
+      break
+    case 'lg':
+      variantStyle = 'text-lg-bold w-350 h-48'
+      break
+    case 'xlg':
+      variantStyle = 'text-lg-bold w-640 h-48'
+      break
+  }
+
+  return (
+    <div>
+      <button
+        disabled={disabled}
+        type={type}
+        className={`${baseStyle} ${disabled ? disabledStyle : backgroundStyle} ${variantStyle} ${className}`}
+      >
+        {children}
+      </button>
+    </div>
+  )
+}
+
+export default Button

--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -17,7 +17,7 @@ const CategoryButton = ({ children }: CategoryButtonProps) => {
       <button
         type="button"
         onClick={handleClick}
-        className={`flex items-center justify-center rounded-15 text-lg-medium border border-green-300 w-100 h-51 md:text-2lg-medium md:w-127 md:h-53 ${isActive ? 'bg-black-100 text-white' : 'text-green-300'}`}
+        className={`flex h-51 w-100 items-center justify-center rounded-15 border border-green-300 text-lg-medium md:h-53 md:w-127 md:text-2lg-medium ${isActive ? 'bg-black-100 text-white' : 'text-green-300'}`}
       >
         {children}
       </button>

--- a/src/components/Filter/index.tsx
+++ b/src/components/Filter/index.tsx
@@ -19,17 +19,17 @@ const Filter = () => {
       <button
         type="button"
         onClick={handleDropDownToggle}
-        className="flex gap-21 items-center justify-center w-107 h-51 rounded-15 border border-green-300 bg-white text-green-300 md:w-160 md:h-53 md:gap-70"
+        className="flex h-51 w-107 items-center justify-center gap-21 rounded-15 border border-green-300 bg-white text-green-300 md:h-53 md:w-160 md:gap-70"
       >
         가격
         <DownArrow />
       </button>
       {isOpen && (
-        <ul className="absolute mt-8 w-107 h-82 rounded-6 shadow-lg bg-white ring-1 ring-black ring-opacity-5 md:w-160">
+        <ul className="absolute mt-8 h-82 w-107 rounded-6 bg-white shadow-lg ring-1 ring-black ring-opacity-5 md:w-160">
           <li className="border-b">
             <button
               type="button"
-              className="w-full h-41 text-sm-medium text-gray-800 cursor-pointer hover:bg-gray-200 hover:rounded-t-6"
+              className="h-41 w-full cursor-pointer text-sm-medium text-gray-800 hover:rounded-t-6 hover:bg-gray-200"
               onClick={handleOptionClick}
             >
               가격이 낮은 순
@@ -38,7 +38,7 @@ const Filter = () => {
           <li>
             <button
               type="button"
-              className="w-full h-41 text-sm-medium text-gray-800 cursor-pointer hover:bg-gray-200 hover:rounded-b-6"
+              className="h-41 w-full cursor-pointer text-sm-medium text-gray-800 hover:rounded-b-6 hover:bg-gray-200"
               onClick={handleOptionClick}
             >
               가격이 높은 순


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

- FP-10

## ✅ 작업 사항
사용 방법은 아래와 같습니다. type, backgroundColor는 필수 값입니다.
```
<Button type="button" size="xlg" backgroundColor="white">
  버튼 테스트
</Button>
```
결과물은 아래와 같습니다.
![스크린샷 2024-07-26 152812](https://github.com/user-attachments/assets/a2d16839-7660-46e7-91bd-b8af1d8ecaa4)


## 👩‍💻 공유 포인트 및 논의 사항
- 피그마에 나와있는 버튼들의 width와 height가 모두 제각각이어서 크게 5가지로 분류했습니다. 기본적으로 size props를 사용하셔서 사이즈를 지정하시되, 범위에서 많이 벗어난 버튼같은 경우는 직접 스타일 지정 하시면 될 것 같습니다 ㅎㅎ
- 예시로 `80*38` 사이즈의 버튼이 필요한 경우 xs 사이즈를 선택하시면 되고, `432*56` 사이즈의 버튼은 `className= 'w-432 h-56'`를 지정해서 사용하시면 됩니다! 

```
xlg: 640*48
lg: 350*48
md: 144*48
sm: 108*38
xs: 95*38
```
- 테일윈드 자동정렬 해주는 플러그인 설치 했습니다! pull 받으시고 npm i 한 번 씩 해주세요! 