### PR TITLE
Refactor: button 공통 컴포넌트 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@storybook/react": "^8.2.5",
         "@storybook/test": "^8.2.5",
         "@svgr/webpack": "^8.1.0",
+        "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -5132,6 +5133,132 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.0.tgz",
+      "integrity": "sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "^7.20.5",
+        "@babel/traverse": "7.23.2",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/generator": {
+      "version": "7.24.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
+      "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.9",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/types": {
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
+      "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@trysound/sax": {
@@ -11365,6 +11492,13 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@storybook/react": "^8.2.5",
     "@storybook/test": "^8.2.5",
     "@svgr/webpack": "^8.1.0",
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,59 +1,49 @@
+/* eslint-disable react/prop-types */
 /* eslint-disable react/function-component-definition */
 
-interface ButtonProps {
-  disabled?: boolean
-  type: 'button' | 'submit' | 'reset' | undefined
-  className?: string
-  backgroundColor: string
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xlg'
-  children: string
+// interface ButtonProps {
+//   disabled?: boolean;
+//   type: 'button' | 'submit' | 'reset' | undefined;
+//   className?: string;
+//   backgroundColor: string;
+//   children: string;
+// }
+
+type ButtonVariant = 'primary' | 'secondary';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
 }
 
 const Button = ({
   disabled = false,
   type = 'button',
-  className,
-  backgroundColor = 'black',
-  size,
+  className = '',
+  variant = 'primary',
   children,
+  onClick,
+  ...rest
 }: ButtonProps) => {
-  const baseStyle = 'text-lg-bold w-350 h-48 rounded-6'
-  const disabledStyle = 'bg-gray-600 cursor-not-allowed text-white'
-  const backgroundStyle =
-    backgroundColor === 'black'
-      ? 'bg-black-100 text-white'
-      : 'bg-white text-black-100 border border-black-100'
-
-  let variantStyle = ''
-  switch (size) {
-    case 'xs':
-      variantStyle = 'font-bold leading-6 text-sm w-95 h-35'
-      break
-    case 'sm':
-      variantStyle = 'text-md-bold w-108 h-38'
-      break
-    case 'md':
-      variantStyle = 'text-lg-bold w-144 h-48'
-      break
-    case 'lg':
-      variantStyle = 'text-lg-bold w-350 h-48'
-      break
-    case 'xlg':
-      variantStyle = 'text-lg-bold w-640 h-48'
-      break
-  }
+  const baseStyle = 'text-lg-bold w-350 h-48 rounded-6';
+  const disabledStyle = 'bg-gray-600 cursor-not-allowed text-white';
+  const variantStyles: Record<ButtonVariant, string> = {
+    primary: 'bg-black-100 text-white',
+    secondary: 'bg-white text-black-100 border border-black-100',
+  };
 
   return (
     <div>
       <button
         disabled={disabled}
         type={type}
-        className={`${baseStyle} ${disabled ? disabledStyle : backgroundStyle} ${variantStyle} ${className}`}
+        className={`${baseStyle} ${disabled ? disabledStyle : variantStyles[variant]} ${className}`}
+        onClick={onClick}
+        {...rest}
       >
         {children}
       </button>
     </div>
-  )
-}
+  );
+};
 
-export default Button
+export default Button;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

- FP-20

## ✅ 작업 사항
버튼 컴포넌트 리팩토링했습니다. 리팩토링 이유는 다음과 같습니다.

기존에는 버튼 size에 따라 xlg, lg, md, sm, xm로 크기를 지정할 수 있었는데, 이는 3가지의 단점이 존재합니다.

1. 기존의 size 지정 방식(xlg, lg, md, sm, xm)은 사용자가 컴포넌트 내부 코드를 확인해야 하는 번거로움이 있었습니다.
2. 원하는 크기가 없을 경우 별도로 className을 통해 스타일을 지정해야합니다.
3. 정확한 size가 없는 경우 근접한 size를 선택해야 하는데 그 기준이 모호합니다.

이러한 문제점을 해결하기 위해 버튼 사용자가 직접 width, height, border 등을 조정할 수 있도록 개선했습니다.

- 사용예제
```
// primary
<Button>테스트 버튼</Button>

// secondary
<Button variant="secondary">테스트 버튼</Button>
```
- 결과물
![스크린샷 2024-07-26 233538](https://github.com/user-attachments/assets/59b9481d-f919-4360-9130-be615871dd25)
![스크린샷 2024-07-26 233549](https://github.com/user-attachments/assets/eb8d668d-fbcb-4232-9ad0-c8dfa6ca536a)