### PR TITLE
Refactor: 체험 상세 페이지 캘린더 리팩토링

### DIFF
--- a/src/apis/activityDetails.ts
+++ b/src/apis/activityDetails.ts
@@ -45,18 +45,12 @@ export const getActivityReviewList = async ({
   return data;
 };
 
-export const postActivityReservation = async ({
-  activityId,
-  formSubmitData,
-}: {
-  activityId: string;
-  formSubmitData: formSubmitDataAtomType;
-}) => {
+export const postActivityReservation = async ({ activityId, scheduleId, headCount }: formSubmitDataAtomType) => {
   const { data } = await axiosRequester({
     options: {
       method: 'POST',
       url: `/activities/${activityId}/reservations`,
-      data: formSubmitData,
+      data: { scheduleId, headCount },
     },
   });
 

--- a/src/components/common/Calendar/index.tsx
+++ b/src/components/common/Calendar/index.tsx
@@ -6,7 +6,7 @@ import Body from './body';
 import Header from './header';
 
 const Calendar = ({ selectedDate, updateDateSelect, availableDates, updateMonthChange, className }: CalendarProps) => {
-  const [viewingMonth, setViewingMonth] = useState<Date>(INITIAL_DATE);
+  const [viewingMonth, setViewingMonth] = useState<Date>(selectedDate || INITIAL_DATE);
   const today = new Date(INITIAL_DATE);
   today.setHours(0, 0, 0, 0);
 

--- a/src/components/common/Counter/index.tsx
+++ b/src/components/common/Counter/index.tsx
@@ -1,24 +1,18 @@
 import Icon from '@/components/common/Icons';
-import { formSubmitDataAtom } from '@/store/activityDetailsAtom';
+import { headCountAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue, useSetAtom } from 'jotai';
 
 const Counter = () => {
-  const setFormSubmitHeadCount = useSetAtom(formSubmitDataAtom);
-  const formSubmitHeadCount = useAtomValue(formSubmitDataAtom);
+  const headCount = useAtomValue(headCountAtom);
+  const setHeadCount = useSetAtom(headCountAtom);
 
   const increment = () => {
-    setFormSubmitHeadCount((prev) => ({
-      ...prev,
-      headCount: prev.headCount + 1,
-    }));
+    setHeadCount((prev) => prev + 1);
   };
 
   const decrement = () => {
-    if (formSubmitHeadCount.headCount > 0) {
-      setFormSubmitHeadCount((prev) => ({
-        ...prev,
-        headCount: prev.headCount - 1,
-      }));
+    if (headCount > 0) {
+      setHeadCount((prev) => prev - 1);
     }
   };
 
@@ -27,7 +21,7 @@ const Counter = () => {
       <button onClick={decrement} aria-label="감소 버튼">
         <Icon.Subtract />
       </button>
-      <span className="text-md-regular text-gray-800">{formSubmitHeadCount.headCount}</span>
+      <span className="text-md-regular text-gray-800">{headCount}</span>
       <button onClick={increment} aria-label="증가 버튼">
         <Icon.Plus />
       </button>

--- a/src/components/common/FloatingBox/DesktopComponents/priceInfo.tsx
+++ b/src/components/common/FloatingBox/DesktopComponents/priceInfo.tsx
@@ -1,8 +1,14 @@
-const PriceInfo = ({ price }: { price: number }) => (
-  <div className="mb-16 flex items-center border-b border-gray-300 pb-11">
-    <span className="mr-5 text-3xl-bold text-black-100">₩ {price.toLocaleString()}</span>
-    <span className="text-xl-regular text-gray-800"> / 인</span>
-  </div>
-);
+import { ReservationPriceAtom } from '@/store/activityDetailsAtom';
+import { useAtomValue } from 'jotai';
+
+const PriceInfo = () => {
+  const price = useAtomValue(ReservationPriceAtom);
+  return (
+    <div className="mb-16 flex items-center border-b border-gray-300 pb-11">
+      <span className="mr-5 text-3xl-bold text-black-100">₩ {price.toLocaleString()}</span>
+      <span className="text-xl-regular text-gray-800"> / 인</span>
+    </div>
+  );
+};
 
 export default PriceInfo;

--- a/src/components/common/FloatingBox/DesktopComponents/priceInfo.tsx
+++ b/src/components/common/FloatingBox/DesktopComponents/priceInfo.tsx
@@ -1,8 +1,8 @@
-import { ReservationPriceAtom } from '@/store/activityDetailsAtom';
+import { reservationPriceAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 
 const PriceInfo = () => {
-  const price = useAtomValue(ReservationPriceAtom);
+  const price = useAtomValue(reservationPriceAtom);
   return (
     <div className="mb-16 flex items-center border-b border-gray-300 pb-11">
       <span className="mr-5 text-3xl-bold text-black-100">₩ {price.toLocaleString()}</span>

--- a/src/components/common/FloatingBox/DesktopComponents/totalPrice.tsx
+++ b/src/components/common/FloatingBox/DesktopComponents/totalPrice.tsx
@@ -1,10 +1,18 @@
-const TotalPrice = ({ price }: { price: number }) => (
-  <div className="flex items-center justify-between">
-    <h2 className="text-xl-bold">총 합계</h2>
-    <div>
-      <span className="text-xl-bold text-black-100">₩ {price.toLocaleString()}</span>
+import { ReservationPriceAtom, headCountAtom } from '@/store/activityDetailsAtom';
+import { useAtomValue } from 'jotai';
+
+const TotalPrice = () => {
+  const price = useAtomValue(ReservationPriceAtom);
+  const headCount = useAtomValue(headCountAtom);
+
+  return (
+    <div className="flex items-center justify-between">
+      <h2 className="text-xl-bold">총 합계</h2>
+      <div>
+        <span className="text-xl-bold text-black-100">₩ {(price * headCount).toLocaleString()}</span>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default TotalPrice;

--- a/src/components/common/FloatingBox/DesktopComponents/totalPrice.tsx
+++ b/src/components/common/FloatingBox/DesktopComponents/totalPrice.tsx
@@ -1,8 +1,8 @@
-import { ReservationPriceAtom, headCountAtom } from '@/store/activityDetailsAtom';
+import { headCountAtom, reservationPriceAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 
 const TotalPrice = () => {
-  const price = useAtomValue(ReservationPriceAtom);
+  const price = useAtomValue(reservationPriceAtom);
   const headCount = useAtomValue(headCountAtom);
 
   return (

--- a/src/components/common/FloatingBox/MobileComponents/dateInfo.tsx
+++ b/src/components/common/FloatingBox/MobileComponents/dateInfo.tsx
@@ -20,14 +20,14 @@ const DateInfo = ({ handleOpenModal }: DateInfoProps) => {
       {dateString ? (
         <span
           onClick={handleOpenModal}
-          className="cursor-pointer border-b border-green-300 text-md-semibold text-green-300"
+          className="cursor-pointer border-b border-green-300 text-md-semibold text-green-300 hover:text-gray-700"
         >
           {dateString}
         </span>
       ) : (
         <span
           onClick={handleOpenModal}
-          className="cursor-pointer border-b border-green-300 text-md-semibold leading-[17px] text-green-300"
+          className="cursor-pointer border-b border-green-300 text-md-semibold leading-[17px] text-green-300 hover:text-gray-700"
         >
           날짜 선택하기
         </span>

--- a/src/components/common/FloatingBox/MobileComponents/dateInfo.tsx
+++ b/src/components/common/FloatingBox/MobileComponents/dateInfo.tsx
@@ -1,17 +1,28 @@
+import { selectedDateAtom, selectedSlotAtom } from '@/store/activityDetailsAtom';
+import { format } from 'date-fns';
+import { useAtomValue } from 'jotai';
+
 interface DateInfoProps {
-  date: string;
-  startTime: string;
-  endTime: string;
-  scheduleId: boolean;
   handleOpenModal: () => void;
 }
 
-const DateInfo = ({ date, startTime, endTime, scheduleId, handleOpenModal }: DateInfoProps) => {
+const DateInfo = ({ handleOpenModal }: DateInfoProps) => {
+  const selectedDate = useAtomValue(selectedDateAtom);
+  const selectedSlot = useAtomValue(selectedSlotAtom);
+
+  const dateString =
+    selectedDate && selectedSlot
+      ? format(selectedDate, 'yy/MM/dd') + ' ' + selectedSlot.startTime + ' ~ ' + selectedSlot.endTime
+      : '';
+
   return (
     <div>
-      {scheduleId ? (
-        <span className="text-md-semibold text-green-300">
-          {date} {startTime} ~ {endTime}
+      {dateString ? (
+        <span
+          onClick={handleOpenModal}
+          className="cursor-pointer border-b border-green-300 text-md-semibold text-green-300"
+        >
+          {dateString}
         </span>
       ) : (
         <span

--- a/src/components/common/FloatingBox/MobileComponents/priceInfo.tsx
+++ b/src/components/common/FloatingBox/MobileComponents/priceInfo.tsx
@@ -1,8 +1,8 @@
-import { ReservationPriceAtom, headCountAtom } from '@/store/activityDetailsAtom';
+import { headCountAtom, reservationPriceAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 
 const PriceInfo = () => {
-  const price = useAtomValue(ReservationPriceAtom);
+  const price = useAtomValue(reservationPriceAtom);
   const headCount = useAtomValue(headCountAtom);
 
   return (

--- a/src/components/common/FloatingBox/MobileComponents/priceInfo.tsx
+++ b/src/components/common/FloatingBox/MobileComponents/priceInfo.tsx
@@ -1,18 +1,17 @@
-import { ReservationPriceAtom, headCountAtom, selectedScheduleStateAtom } from '@/store/activityDetailsAtom';
+import { ReservationPriceAtom, headCountAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 
 const PriceInfo = () => {
-  const isSelectedSchedule = useAtomValue(selectedScheduleStateAtom);
   const price = useAtomValue(ReservationPriceAtom);
   const headCount = useAtomValue(headCountAtom);
 
   return (
     <div className="flex items-center">
       <span className="mr-6 text-xl-bold text-black-100">
-        ₩ {isSelectedSchedule ? price * headCount : price.toLocaleString()}
+        ₩ {headCount > 0 ? price * headCount : price.toLocaleString()}
       </span>
       <span className="flex items-center text-2lg-medium text-green-300">
-        {isSelectedSchedule ? `/ 총 ${headCount}인` : '/ 1인'}
+        {headCount > 0 ? `/ 총 ${headCount}인` : '/ 인'}
       </span>
     </div>
   );

--- a/src/components/common/FloatingBox/MobileComponents/priceInfo.tsx
+++ b/src/components/common/FloatingBox/MobileComponents/priceInfo.tsx
@@ -1,13 +1,19 @@
-interface PriceInfoProps {
-  price: number;
-  capacity: number;
-}
+import { ReservationPriceAtom, headCountAtom, selectedScheduleStateAtom } from '@/store/activityDetailsAtom';
+import { useAtomValue } from 'jotai';
 
-const PriceInfo = ({ price, capacity }: PriceInfoProps) => {
+const PriceInfo = () => {
+  const isSelectedSchedule = useAtomValue(selectedScheduleStateAtom);
+  const price = useAtomValue(ReservationPriceAtom);
+  const headCount = useAtomValue(headCountAtom);
+
   return (
     <div className="flex items-center">
-      <span className="mr-6 text-xl-bold text-black-100">₩ {price.toLocaleString()}</span>
-      <span className="text-2lg-medium text-green-300"> / 총 {capacity}인</span>
+      <span className="mr-6 text-xl-bold text-black-100">
+        ₩ {isSelectedSchedule ? price * headCount : price.toLocaleString()}
+      </span>
+      <span className="flex items-center text-2lg-medium text-green-300">
+        {isSelectedSchedule ? `/ 총 ${headCount}인` : '/ 1인'}
+      </span>
     </div>
   );
 };

--- a/src/components/common/FloatingBox/TabletComponents/footer.tsx
+++ b/src/components/common/FloatingBox/TabletComponents/footer.tsx
@@ -1,11 +1,16 @@
+import { ReservationPriceAtom, headCountAtom } from '@/store/activityDetailsAtom';
+import { useAtomValue } from 'jotai';
+
 const Footer = () => {
-  const price = 100000;
+  const price = useAtomValue(ReservationPriceAtom);
+  const headCount = useAtomValue(headCountAtom);
+
   return (
     <div>
       <footer className="flex items-center justify-between px-24 py-17">
         <h2 className="text-xl-bold">총 합계</h2>
         <div>
-          <span className="text-xl-bold text-black-100">₩ {price.toLocaleString()}</span>
+          <span className="text-xl-bold text-black-100">₩ {(price * headCount).toLocaleString()}</span>
         </div>
       </footer>
     </div>

--- a/src/components/common/FloatingBox/TabletComponents/footer.tsx
+++ b/src/components/common/FloatingBox/TabletComponents/footer.tsx
@@ -1,8 +1,8 @@
-import { ReservationPriceAtom, headCountAtom } from '@/store/activityDetailsAtom';
+import { headCountAtom, reservationPriceAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 
 const Footer = () => {
-  const price = useAtomValue(ReservationPriceAtom);
+  const price = useAtomValue(reservationPriceAtom);
   const headCount = useAtomValue(headCountAtom);
 
   return (

--- a/src/components/common/FloatingBox/TabletComponents/header.tsx
+++ b/src/components/common/FloatingBox/TabletComponents/header.tsx
@@ -1,8 +1,8 @@
-import { ReservationPriceAtom } from '@/store/activityDetailsAtom';
+import { reservationPriceAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 
 const Header = () => {
-  const price = useAtomValue(ReservationPriceAtom);
+  const price = useAtomValue(reservationPriceAtom);
   return (
     <div>
       <header className="flex items-center border-b border-gray-300 px-24 pb-16 pt-24">

--- a/src/components/common/FloatingBox/TabletComponents/header.tsx
+++ b/src/components/common/FloatingBox/TabletComponents/header.tsx
@@ -1,5 +1,8 @@
+import { ReservationPriceAtom } from '@/store/activityDetailsAtom';
+import { useAtomValue } from 'jotai';
+
 const Header = () => {
-  const price = 10000;
+  const price = useAtomValue(ReservationPriceAtom);
   return (
     <div>
       <header className="flex items-center border-b border-gray-300 px-24 pb-16 pt-24">

--- a/src/components/common/FloatingBox/TabletComponents/main.tsx
+++ b/src/components/common/FloatingBox/TabletComponents/main.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/common/Button';
 import Counter from '@/components/common/Counter';
 import Modal from '@/components/common/Modal';
 import { useActivityReservationMutation } from '@/hooks/useReservationMutation';
-import { activityIdAtom, formSubmitDataAtom } from '@/store/activityDetailsAtom';
+import { activityIdAtom, headCountAtom, scheduleIdAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 import { useState } from 'react';
 
@@ -16,10 +16,11 @@ const Main = () => {
 
   const { submitReservation } = useActivityReservationMutation();
   const activityId = useAtomValue(activityIdAtom);
-  const submitFormData = useAtomValue(formSubmitDataAtom);
+  const headCount = useAtomValue(headCountAtom);
+  const scheduleId = useAtomValue(scheduleIdAtom);
 
   const handleReservationFormSubmit = () => {
-    submitReservation(activityId, submitFormData);
+    submitReservation({ activityId, scheduleId, headCount });
   };
 
   return (
@@ -29,7 +30,7 @@ const Main = () => {
         <button onClick={handleDateSelectModal} className="mb-27">
           날짜 선택하기
         </button>
-        {isModalOpen && <Modal.DateSelect classNames="absolute right-0 top-0" setIsModalOpen={setIsModalOpen} />}
+        {isModalOpen && <Modal.DateSelect classNames="absolute right-0 top-0 z-50" setIsModalOpen={setIsModalOpen} />}
         <h2 className="mb-5 text-xl-bold">참여 인원 수</h2>
         <div className="mb-32">
           <Counter />

--- a/src/components/common/FloatingBox/TabletComponents/main.tsx
+++ b/src/components/common/FloatingBox/TabletComponents/main.tsx
@@ -2,7 +2,14 @@ import Button from '@/components/common/Button';
 import Counter from '@/components/common/Counter';
 import Modal from '@/components/common/Modal';
 import { useActivityReservationMutation } from '@/hooks/useReservationMutation';
-import { activityIdAtom, headCountAtom, scheduleIdAtom } from '@/store/activityDetailsAtom';
+import {
+  activityIdAtom,
+  headCountAtom,
+  scheduleIdAtom,
+  selectedDateAtom,
+  selectedSlotAtom,
+} from '@/store/activityDetailsAtom';
+import { format } from 'date-fns';
 import { useAtomValue } from 'jotai';
 import { useState } from 'react';
 
@@ -18,24 +25,49 @@ const Main = () => {
   const activityId = useAtomValue(activityIdAtom);
   const headCount = useAtomValue(headCountAtom);
   const scheduleId = useAtomValue(scheduleIdAtom);
+  const selectedDate = useAtomValue(selectedDateAtom);
+  const selectedSlot = useAtomValue(selectedSlotAtom);
+
+  const dateString =
+    selectedDate && selectedSlot
+      ? format(selectedDate, 'yy/MM/dd') + ' ' + selectedSlot.startTime + ' ~ ' + selectedSlot.endTime
+      : '';
 
   const handleReservationFormSubmit = () => {
     submitReservation({ activityId, scheduleId, headCount });
   };
 
+  const isReservationButtonActive = selectedDate && selectedSlot && headCount > 0 ? false : true;
+
   return (
     <div>
       <main className="border-b border-gray-300 px-24 pb-24 pt-13">
         <h2 className="mb-5 text-xl-bold">날짜</h2>
-        <button onClick={handleDateSelectModal} className="mb-27">
-          날짜 선택하기
-        </button>
+        {dateString ? (
+          <span
+            onClick={handleDateSelectModal}
+            className="cursor-pointer border-b border-black-100 text-lg-semibold text-black-100 hover:text-gray-700"
+          >
+            {dateString}
+          </span>
+        ) : (
+          <span
+            onClick={handleDateSelectModal}
+            className="cursor-pointer border-b border-black-100 text-lg-semibold text-black-100 hover:text-gray-700"
+          >
+            날짜 선택하기
+          </span>
+        )}
         {isModalOpen && <Modal.DateSelect classNames="absolute right-0 top-0 z-50" setIsModalOpen={setIsModalOpen} />}
-        <h2 className="mb-5 text-xl-bold">참여 인원 수</h2>
-        <div className="mb-32">
+        <h2 className="mt-27 text-xl-bold">참여 인원 수</h2>
+        <div className="mb-32 mt-5">
           <Counter />
         </div>
-        <Button.Default className="h-56 w-203" onClick={handleReservationFormSubmit}>
+        <Button.Default
+          className="h-56 w-203"
+          onClick={handleReservationFormSubmit}
+          disabled={isReservationButtonActive}
+        >
           예약하기
         </Button.Default>
       </main>

--- a/src/components/common/FloatingBox/TabletComponents/main.tsx
+++ b/src/components/common/FloatingBox/TabletComponents/main.tsx
@@ -15,6 +15,11 @@ import { useState } from 'react';
 
 const Main = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const activityId = useAtomValue(activityIdAtom);
+  const headCount = useAtomValue(headCountAtom);
+  const scheduleId = useAtomValue(scheduleIdAtom);
+  const selectedDate = useAtomValue(selectedDateAtom);
+  const selectedSlot = useAtomValue(selectedSlotAtom);
 
   const handleDateSelectModal = () => {
     // TODO: 모달 여닫는 기능 구현
@@ -22,22 +27,17 @@ const Main = () => {
   };
 
   const { submitReservation } = useActivityReservationMutation();
-  const activityId = useAtomValue(activityIdAtom);
-  const headCount = useAtomValue(headCountAtom);
-  const scheduleId = useAtomValue(scheduleIdAtom);
-  const selectedDate = useAtomValue(selectedDateAtom);
-  const selectedSlot = useAtomValue(selectedSlotAtom);
+
+  const handleReservationSubmit = () => {
+    submitReservation({ activityId, scheduleId, headCount });
+  };
+
+  const isReservationButtonActive = selectedDate && selectedSlot && headCount > 0 ? false : true;
 
   const dateString =
     selectedDate && selectedSlot
       ? format(selectedDate, 'yy/MM/dd') + ' ' + selectedSlot.startTime + ' ~ ' + selectedSlot.endTime
       : '';
-
-  const handleReservationFormSubmit = () => {
-    submitReservation({ activityId, scheduleId, headCount });
-  };
-
-  const isReservationButtonActive = selectedDate && selectedSlot && headCount > 0 ? false : true;
 
   return (
     <div>
@@ -64,8 +64,8 @@ const Main = () => {
           <Counter />
         </div>
         <Button.Default
-          className="h-56 w-203"
-          onClick={handleReservationFormSubmit}
+          className="h-56 w-203 hover:bg-gray-800"
+          onClick={handleReservationSubmit}
           disabled={isReservationButtonActive}
         >
           예약하기

--- a/src/components/common/FloatingBox/desktop.tsx
+++ b/src/components/common/FloatingBox/desktop.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { useActivityReservationMutation } from '@/hooks/useReservationMutation';
-import { headCountAtom, scheduleIdAtom } from '@/store/activityDetailsAtom';
+import { headCountAtom, scheduleIdAtom, selectedDateAtom, selectedSlotAtom } from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 
 import Button from '../Button';
@@ -16,6 +16,8 @@ const Desktop = ({
   classNames: string;
   buttonLabel: string;
 }) => {
+  const selectedDate = useAtomValue(selectedDateAtom);
+  const selectedSlot = useAtomValue(selectedSlotAtom);
   const scheduleId = useAtomValue(scheduleIdAtom);
   const headCount = useAtomValue(headCountAtom);
 
@@ -25,6 +27,8 @@ const Desktop = ({
     submitReservation({ activityId, scheduleId, headCount });
   };
 
+  const isReservationButtonActive = selectedDate && selectedSlot && headCount > 0 ? false : true;
+
   return (
     <section
       className={`${classNames} h-746 rounded-8 border border-gray-300 bg-white px-24 py-17 shadow-[0px_10px_30px_3px_rgba(5,16,55,0.15)]`}
@@ -33,7 +37,11 @@ const Desktop = ({
       <h2 className="mb-16 text-xl-bold">날짜</h2>
       <ReservationScheduleSelect />
       <DesktopComponents.ParticipantCounter />
-      <Button.Default className="h-56 w-full" onClick={handleReservationFormSubmit}>
+      <Button.Default
+        disabled={isReservationButtonActive}
+        className="h-56 w-full"
+        onClick={handleReservationFormSubmit}
+      >
         {buttonLabel}
       </Button.Default>
       <div className="mb-16 border-b border-gray-300 pb-24"></div>

--- a/src/components/common/FloatingBox/desktop.tsx
+++ b/src/components/common/FloatingBox/desktop.tsx
@@ -1,134 +1,43 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { INITIAL_DATE } from '@/constants/date';
-import { useActivityAvailableSchedule } from '@/hooks/useActivityAvailableSchedule';
 import { useActivityReservationMutation } from '@/hooks/useReservationMutation';
-import { formSubmitDataAtom } from '@/store/activityDetailsAtom';
-import { DaySchedule, TimeSlot } from '@/types/availableSchedulesTypes';
-import { useQueryClient } from '@tanstack/react-query';
-import { useAtom } from 'jotai';
-import { useCallback, useEffect, useState } from 'react';
+import { headCountAtom, scheduleIdAtom } from '@/store/activityDetailsAtom';
+import { useAtomValue } from 'jotai';
+
 import Button from '../Button';
-import Calendar from '../Calendar';
+import ReservationScheduleSelect from '../ReservationScheduleSelect';
 import DesktopComponents from './DesktopComponents';
 
-const Desktop = ({ activityId }: { activityId: string }) => {
-  const queryClient = useQueryClient();
-
-  const [currentMonth, setCurrentMonth] = useState<Date>(INITIAL_DATE);
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [selectedSlot, setSelectedSlot] = useState<TimeSlot | null>(null);
-  const [formSubmitScheduleId, setFormSubmitScheduleId] = useAtom(formSubmitDataAtom);
-
-  const twoDigitMonth = String(currentMonth.getMonth() + 1).padStart(2, '0');
-
-  const { availableSchedule, isLoading, error } = useActivityAvailableSchedule({
-    activityId,
-    year: currentMonth.getFullYear(),
-    month: twoDigitMonth,
-  });
-
-  const price = 10000;
-
-  INITIAL_DATE.setHours(0, 0, 0, 0);
-
-  const availableDates =
-    availableSchedule?.map((schedule) => new Date(schedule.date)).filter((date) => date >= INITIAL_DATE) || [];
-
-  const getFirstActivityDateOfMonth = useCallback(
-    (year: number, month: number) => {
-      return (
-        availableSchedule?.find((schedule) => {
-          const scheduleDate = new Date(schedule.date);
-          return (
-            scheduleDate >= INITIAL_DATE && scheduleDate.getFullYear() === year && scheduleDate.getMonth() === month
-          );
-        })?.date || null
-      );
-    },
-    [availableSchedule],
-  );
-
-  const getSelectedDateSlots = useCallback((selectedDate: Date | null, schedules?: DaySchedule[]) => {
-    const selectedSchedule = schedules?.find(
-      (schedule) => new Date(schedule.date).toDateString() === selectedDate?.toDateString(),
-    );
-
-    return selectedSchedule ? selectedSchedule.times : [];
-  }, []);
-
-  const getFirstSlotOfDate = useCallback(
-    (date: Date | null) => {
-      const slots = getSelectedDateSlots(date, availableSchedule);
-      if (slots.length > 0) {
-        const firstSlot = slots[0];
-        setSelectedSlot(firstSlot);
-        setFormSubmitScheduleId((prev) => ({ ...prev, scheduleId: firstSlot.id }));
-      } else {
-        setSelectedSlot(null);
-      }
-    },
-    [availableSchedule, getSelectedDateSlots],
-  );
-
-  const updateDateSelect = (date: Date | null) => {
-    setSelectedDate(date);
-    getFirstSlotOfDate(date);
-  };
-
-  const handleSlotSelect = (slot: TimeSlot) => {
-    setSelectedSlot(slot);
-    setFormSubmitScheduleId((prev) => ({ ...prev, scheduleId: slot.id }));
-    // 폼 데이터 업데이트 slot.id -> scheduleId
-  };
-
-  const updateMonthChange = (newMonth: Date) => {
-    setCurrentMonth(newMonth);
-  };
-
-  useEffect(() => {
-    // 데이터가 없을 경우
-    if (!availableSchedule) return;
-
-    const firstActivityDate = getFirstActivityDateOfMonth(currentMonth.getFullYear(), currentMonth.getMonth());
-
-    if (firstActivityDate) {
-      updateDateSelect(new Date(firstActivityDate));
-    } else {
-      setSelectedDate(null);
-      setSelectedSlot(null);
-    }
-  }, [availableSchedule]);
+const Desktop = ({
+  activityId,
+  classNames,
+  buttonLabel,
+}: {
+  activityId: string;
+  classNames: string;
+  buttonLabel: string;
+}) => {
+  const scheduleId = useAtomValue(scheduleIdAtom);
+  const headCount = useAtomValue(headCountAtom);
 
   const { submitReservation, isPending } = useActivityReservationMutation();
 
   const handleReservationFormSubmit = () => {
-    submitReservation(activityId, formSubmitScheduleId);
+    submitReservation({ activityId, scheduleId, headCount });
   };
 
   return (
-    <section className="sticky top-0 h-746 w-384 rounded-8 border border-gray-300 bg-white px-24 py-17 shadow-[0px_10px_30px_3px_rgba(5,16,55,0.15)]">
-      <DesktopComponents.PriceInfo price={price} />
+    <section
+      className={`${classNames} h-746 rounded-8 border border-gray-300 bg-white px-24 py-17 shadow-[0px_10px_30px_3px_rgba(5,16,55,0.15)]`}
+    >
+      <DesktopComponents.PriceInfo />
       <h2 className="mb-16 text-xl-bold">날짜</h2>
-      <Calendar
-        selectedDate={selectedDate}
-        updateDateSelect={updateDateSelect}
-        availableDates={availableDates}
-        updateMonthChange={updateMonthChange}
-        className="mx-auto mb-16 h-241 pt-[11px]"
-      />
-      <DesktopComponents.TimeSlotSelection
-        selectedDate={selectedDate}
-        selectedSlot={selectedSlot}
-        handleSlotSelect={handleSlotSelect}
-        availableSchedule={availableSchedule}
-        getSelectedDateSlots={getSelectedDateSlots}
-      />
+      <ReservationScheduleSelect />
       <DesktopComponents.ParticipantCounter />
-      <Button.Default className="h-56 w-336" onClick={handleReservationFormSubmit}>
-        예약하기
+      <Button.Default className="h-56 w-full" onClick={handleReservationFormSubmit}>
+        {buttonLabel}
       </Button.Default>
       <div className="mb-16 border-b border-gray-300 pb-24"></div>
-      <DesktopComponents.TotalPrice price={price} />
+      <DesktopComponents.TotalPrice />
     </section>
   );
 };

--- a/src/components/common/FloatingBox/desktop.tsx
+++ b/src/components/common/FloatingBox/desktop.tsx
@@ -23,7 +23,7 @@ const Desktop = ({
 
   const { submitReservation, isPending } = useActivityReservationMutation();
 
-  const handleReservationFormSubmit = () => {
+  const handleReservationSubmit = () => {
     submitReservation({ activityId, scheduleId, headCount });
   };
 
@@ -39,8 +39,8 @@ const Desktop = ({
       <DesktopComponents.ParticipantCounter />
       <Button.Default
         disabled={isReservationButtonActive}
-        className="h-56 w-full"
-        onClick={handleReservationFormSubmit}
+        className="h-56 w-full hover:bg-gray-800"
+        onClick={handleReservationSubmit}
       >
         {buttonLabel}
       </Button.Default>

--- a/src/components/common/FloatingBox/mobile.tsx
+++ b/src/components/common/FloatingBox/mobile.tsx
@@ -1,3 +1,5 @@
+import { headCountAtom, selectedDateAtom, selectedSlotAtom } from '@/store/activityDetailsAtom';
+import { useAtomValue } from 'jotai';
 import { useState } from 'react';
 
 import Button from '../Button';
@@ -6,6 +8,9 @@ import MobileComponents from './MobileComponents';
 
 const Mobile = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const headCount = useAtomValue(headCountAtom);
+  const selectedDate = useAtomValue(selectedDateAtom);
+  const selectedSlot = useAtomValue(selectedSlotAtom);
 
   const handleReservation = () => {
     // TODO: 예약하기 기능 구현
@@ -14,6 +19,8 @@ const Mobile = () => {
   const handleOpenModal = () => {
     setIsModalOpen((prev) => !prev);
   };
+
+  const isReservationButtonActive = selectedDate && selectedSlot && headCount > 0 ? false : true;
 
   return (
     <>
@@ -25,7 +32,7 @@ const Mobile = () => {
             <MobileComponents.PriceInfo />
             <MobileComponents.DateInfo handleOpenModal={handleOpenModal} />
           </div>
-          <Button.Default onClick={handleReservation} className="h-54 w-106">
+          <Button.Default disabled={isReservationButtonActive} onClick={handleReservation} className="h-54 w-106">
             예약하기
           </Button.Default>
         </div>

--- a/src/components/common/FloatingBox/mobile.tsx
+++ b/src/components/common/FloatingBox/mobile.tsx
@@ -17,18 +17,13 @@ const Mobile = () => {
 
   return (
     <>
-      {isModalOpen && <DateSelectModal classNames="fixed bottom-0 w-full z-[9999]" setIsModalOpen={setIsModalOpen} />}
+      {isModalOpen && <DateSelectModal setIsModalOpen={setIsModalOpen} classNames="fixed bottom-0 w-full z-[9999]" />}
+
       <div className="fixed bottom-0 left-0 right-0 z-50 h-83 w-full max-w-[743px] border-y border-gray-300 bg-white">
         <div className="flex items-center justify-between px-16 py-16">
           <div className="flex flex-col">
-            <MobileComponents.PriceInfo price={10000} capacity={10} />
-            <MobileComponents.DateInfo
-              date="22/11/14"
-              startTime="14:00"
-              endTime="15:00"
-              scheduleId={false}
-              handleOpenModal={handleOpenModal}
-            />
+            <MobileComponents.PriceInfo />
+            <MobileComponents.DateInfo handleOpenModal={handleOpenModal} />
           </div>
           <Button.Default onClick={handleReservation} className="h-54 w-106">
             예약하기

--- a/src/components/common/FloatingBox/mobile.tsx
+++ b/src/components/common/FloatingBox/mobile.tsx
@@ -1,4 +1,11 @@
-import { headCountAtom, selectedDateAtom, selectedSlotAtom } from '@/store/activityDetailsAtom';
+import { useActivityReservationMutation } from '@/hooks/useReservationMutation';
+import {
+  activityIdAtom,
+  headCountAtom,
+  scheduleIdAtom,
+  selectedDateAtom,
+  selectedSlotAtom,
+} from '@/store/activityDetailsAtom';
 import { useAtomValue } from 'jotai';
 import { useState } from 'react';
 
@@ -8,12 +15,16 @@ import MobileComponents from './MobileComponents';
 
 const Mobile = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const activityId = useAtomValue(activityIdAtom);
+  const scheduleId = useAtomValue(scheduleIdAtom);
   const headCount = useAtomValue(headCountAtom);
   const selectedDate = useAtomValue(selectedDateAtom);
   const selectedSlot = useAtomValue(selectedSlotAtom);
 
-  const handleReservation = () => {
-    // TODO: 예약하기 기능 구현
+  const { submitReservation } = useActivityReservationMutation();
+
+  const handleReservationSubmit = () => {
+    submitReservation({ activityId, scheduleId, headCount });
   };
 
   const handleOpenModal = () => {
@@ -32,7 +43,11 @@ const Mobile = () => {
             <MobileComponents.PriceInfo />
             <MobileComponents.DateInfo handleOpenModal={handleOpenModal} />
           </div>
-          <Button.Default disabled={isReservationButtonActive} onClick={handleReservation} className="h-54 w-106">
+          <Button.Default
+            disabled={isReservationButtonActive}
+            onClick={handleReservationSubmit}
+            className="h-54 w-106 hover:bg-gray-800"
+          >
             예약하기
           </Button.Default>
         </div>

--- a/src/components/common/Modal/DateSelect/footer.tsx
+++ b/src/components/common/Modal/DateSelect/footer.tsx
@@ -4,10 +4,9 @@ import { SetStateAction, useSetAtom } from 'jotai';
 import { Dispatch } from 'react';
 
 interface FooterProps {
-  // isReservationPossible: boolean;
   setIsModalOpen?: Dispatch<SetStateAction<boolean>>;
 }
-// prop -> isReservationPossible 일정 선택 시 버튼 활성화 기능 구현 예정
+
 const Footer = ({ setIsModalOpen }: FooterProps) => {
   const setIsSelectedSchedule = useSetAtom(selectedScheduleStateAtom);
 
@@ -19,7 +18,7 @@ const Footer = ({ setIsModalOpen }: FooterProps) => {
   return (
     <div>
       <footer>
-        <Button.Default /*disabled={!isReservationPossible}*/ onClick={handleScheduleSelect} className="h-56 w-full">
+        <Button.Default onClick={handleScheduleSelect} className="h-56 w-full">
           확인
         </Button.Default>
       </footer>

--- a/src/components/common/Modal/DateSelect/footer.tsx
+++ b/src/components/common/Modal/DateSelect/footer.tsx
@@ -1,14 +1,25 @@
 import Button from '@/components/common/Button';
+import { selectedScheduleStateAtom } from '@/store/activityDetailsAtom';
+import { SetStateAction, useSetAtom } from 'jotai';
+import { Dispatch } from 'react';
 
 interface FooterProps {
-  isReservationPossible: boolean;
+  // isReservationPossible: boolean;
+  setIsModalOpen?: Dispatch<SetStateAction<boolean>>;
 }
+// prop -> isReservationPossible 일정 선택 시 버튼 활성화 기능 구현 예정
+const Footer = ({ setIsModalOpen }: FooterProps) => {
+  const setIsSelectedSchedule = useSetAtom(selectedScheduleStateAtom);
 
-const Footer = ({ isReservationPossible }: FooterProps) => {
+  const handleScheduleSelect = () => {
+    setIsModalOpen?.(false);
+    setIsSelectedSchedule(true);
+  };
+
   return (
     <div>
       <footer>
-        <Button.Default disabled={!isReservationPossible} className="h-56 w-full">
+        <Button.Default /*disabled={!isReservationPossible}*/ onClick={handleScheduleSelect} className="h-56 w-full">
           확인
         </Button.Default>
       </footer>

--- a/src/components/common/Modal/DateSelect/header.tsx
+++ b/src/components/common/Modal/DateSelect/header.tsx
@@ -1,9 +1,9 @@
 import Icon from '@/components/common/Icons';
 import { Dispatch, SetStateAction } from 'react';
 
-const Header = ({ setIsModalOpen }: { setIsModalOpen: Dispatch<SetStateAction<boolean>> }) => {
+const Header = ({ setIsModalOpen }: { setIsModalOpen?: Dispatch<SetStateAction<boolean>> }) => {
   const handleCloseModal = () => {
-    setIsModalOpen(false);
+    setIsModalOpen?.(false);
   };
 
   return (

--- a/src/components/common/Modal/DateSelect/index.tsx
+++ b/src/components/common/Modal/DateSelect/index.tsx
@@ -30,7 +30,7 @@ const DateSelectModal = ({
           </>
         )}
       </main>
-      <Footer setIsModalOpen={setIsModalOpen} /> {/*prop -> isReservationPossible={isReservationPossible}*/}
+      <Footer setIsModalOpen={setIsModalOpen} />
     </div>
   );
 };

--- a/src/components/common/Modal/DateSelect/index.tsx
+++ b/src/components/common/Modal/DateSelect/index.tsx
@@ -1,15 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { INITIAL_DATE } from '@/constants/date';
-import { useActivityAvailableSchedule } from '@/hooks/useActivityAvailableSchedule';
-import { activityIdAtom, formSubmitDataAtom } from '@/store/activityDetailsAtom';
-import { DaySchedule, TimeSlot } from '@/types/availableSchedulesTypes';
-import { useAtom, useAtomValue } from 'jotai';
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+import useViewportSize from '@/hooks/useViewportSize';
+import { Dispatch, SetStateAction } from 'react';
 
-import Calendar from '../../Calendar';
+import Counter from '../../Counter';
+import ReservationScheduleSelect from '../../ReservationScheduleSelect';
 import Footer from './footer';
 import Header from './header';
-import TimeSlotSelection from './timeSlotSelection';
 
 const DateSelectModal = ({
   setIsModalOpen,
@@ -18,111 +14,23 @@ const DateSelectModal = ({
   setIsModalOpen: Dispatch<SetStateAction<boolean>>;
   classNames: string;
 }) => {
-  const [currentMonth, setCurrentMonth] = useState<Date>(INITIAL_DATE);
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [selectedSlot, setSelectedSlot] = useState<TimeSlot | null>(null);
-  const [formSubmitScheduleId, setFormSubmitScheduleId] = useAtom(formSubmitDataAtom);
-  const activityId = useAtomValue(activityIdAtom); // 전역 activityId atom
+  const viewportSize = useViewportSize();
 
-  const twoDigitMonth = String(currentMonth.getMonth() + 1).padStart(2, '0');
-
-  const { availableSchedule, isLoading, error } = useActivityAvailableSchedule({
-    activityId,
-    year: currentMonth.getFullYear(),
-    month: twoDigitMonth,
-  });
-
-  INITIAL_DATE.setHours(0, 0, 0, 0);
-
-  const availableDates =
-    availableSchedule?.map((schedule) => new Date(schedule.date)).filter((date) => date >= INITIAL_DATE) || [];
-
-  const getFirstActivityDateOfMonth = useCallback(
-    (year: number, month: number) => {
-      return (
-        availableSchedule?.find((schedule) => {
-          const scheduleDate = new Date(schedule.date);
-          return (
-            scheduleDate >= INITIAL_DATE && scheduleDate.getFullYear() === year && scheduleDate.getMonth() === month
-          );
-        })?.date || null
-      );
-    },
-    [availableSchedule],
-  );
-
-  const getSelectedDateSlots = useCallback((selectedDate: Date | null, schedules?: DaySchedule[]) => {
-    const selectedSchedule = schedules?.find(
-      (schedule) => new Date(schedule.date).toDateString() === selectedDate?.toDateString(),
-    );
-
-    return selectedSchedule ? selectedSchedule.times : [];
-  }, []);
-
-  const getFirstSlotOfDate = useCallback(
-    (date: Date | null) => {
-      const slots = getSelectedDateSlots(date, availableSchedule);
-      if (slots.length > 0) {
-        const firstSlot = slots[0];
-        setSelectedSlot(firstSlot);
-        setFormSubmitScheduleId((prev) => ({ ...prev, scheduleId: firstSlot.id }));
-      } else {
-        setSelectedSlot(null);
-      }
-    },
-    [availableSchedule, getSelectedDateSlots],
-  );
-
-  const updateDateSelect = (date: Date | null) => {
-    setSelectedDate(date);
-    getFirstSlotOfDate(date);
-  };
-
-  const handleSlotSelect = (slot: TimeSlot) => {
-    setSelectedSlot(slot);
-    setFormSubmitScheduleId((prev) => ({ ...prev, scheduleId: slot.id }));
-  };
-
-  const updateMonthChange = (newMonth: Date) => {
-    setCurrentMonth(newMonth);
-  };
-
-  useEffect(() => {
-    // 데이터가 없을 경우
-    if (!availableSchedule) return;
-
-    const firstActivityDate = getFirstActivityDateOfMonth(currentMonth.getFullYear(), currentMonth.getMonth());
-
-    if (firstActivityDate) {
-      updateDateSelect(new Date(firstActivityDate));
-    } else {
-      setSelectedDate(null);
-      setSelectedSlot(null);
-    }
-  }, [availableSchedule]);
-
-  const isReservationPossible = selectedDate !== null && selectedSlot !== null;
+  const isMobile = viewportSize === 'mobile';
 
   return (
-    <div className={`${classNames} z-50 w-480 rounded-24 bg-white px-24 py-32`}>
+    <div className={`${classNames} w-480 rounded-24 bg-white px-24 py-32`}>
       <Header setIsModalOpen={setIsModalOpen} />
       <main className="mb-64">
-        <Calendar
-          selectedDate={selectedDate}
-          updateDateSelect={updateDateSelect}
-          availableDates={availableDates}
-          updateMonthChange={updateMonthChange}
-          className="mx-auto mb-32"
-        />
-        <TimeSlotSelection
-          selectedDate={selectedDate}
-          selectedSlot={selectedSlot}
-          handleSlotSelect={handleSlotSelect}
-          availableSchedule={availableSchedule}
-          getSelectedDateSlots={getSelectedDateSlots}
-        />
+        <ReservationScheduleSelect />
+        {isMobile && (
+          <>
+            <h1 className="mb-14 text-2lg-bold text-black-100">참여 인원수 </h1>
+            <Counter />
+          </>
+        )}
       </main>
-      <Footer isReservationPossible={isReservationPossible} />
+      <Footer setIsModalOpen={setIsModalOpen} /> {/*prop -> isReservationPossible={isReservationPossible}*/}
     </div>
   );
 };

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -5,7 +5,7 @@ interface PaginationProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
-  isPlaceholderData: boolean;
+  isPlaceholderData?: boolean;
 }
 
 const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onPageChange, isPlaceholderData }) => {

--- a/src/components/common/ReservationScheduleSelect/index.tsx
+++ b/src/components/common/ReservationScheduleSelect/index.tsx
@@ -1,0 +1,129 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { INITIAL_DATE } from '@/constants/date';
+import { useActivityAvailableSchedule } from '@/hooks/useActivityAvailableSchedule';
+import { activityIdAtom, scheduleIdAtom, selectedDateAtom, selectedSlotAtom } from '@/store/activityDetailsAtom';
+import { DaySchedule, TimeSlot } from '@/types/availableSchedulesTypes';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useCallback, useEffect, useState } from 'react';
+
+import Calendar from '../Calendar';
+import TimeSlotSelection from '../FloatingBox/DesktopComponents/timeSlotSelection';
+
+const ReservationScheduleSelect = () => {
+  const [currentDate, setCurrentDate] = useState<Date>(INITIAL_DATE);
+
+  const [selectedDate, setSelectedDate] = useAtom<Date | null>(selectedDateAtom);
+  const [selectedSlot, setSelectedSlot] = useAtom(selectedSlotAtom);
+
+  const setScheduleId = useSetAtom(scheduleIdAtom);
+
+  const activityId = useAtomValue(activityIdAtom);
+
+  const twoDigitMonth = String(currentDate.getMonth() + 1).padStart(2, '0');
+
+  const { availableSchedule, isLoading, error } = useActivityAvailableSchedule({
+    activityId,
+    year: currentDate.getFullYear(),
+    month: twoDigitMonth,
+  });
+
+  INITIAL_DATE.setHours(0, 0, 0, 0);
+
+  const availableDates =
+    availableSchedule?.map((schedule) => new Date(schedule.date)).filter((date) => date >= INITIAL_DATE) || [];
+
+  const getFirstActivityDateOfMonth = useCallback(
+    (year: number, month: number) => {
+      return (
+        availableSchedule?.find((schedule) => {
+          const scheduleDate = new Date(schedule.date);
+          return (
+            scheduleDate >= INITIAL_DATE && scheduleDate.getFullYear() === year && scheduleDate.getMonth() === month
+          );
+        })?.date || null
+      );
+    },
+    [availableSchedule],
+  );
+
+  const getSelectedDateSlots = useCallback((selectedDate: Date | null, schedules?: DaySchedule[]) => {
+    const selectedSchedule = schedules?.find(
+      (schedule) => new Date(schedule.date).toDateString() === selectedDate?.toDateString(),
+    );
+
+    return selectedSchedule ? selectedSchedule.times : [];
+  }, []);
+
+  const getFirstSlotOfDate = useCallback(
+    (date: Date | null) => {
+      const slots = getSelectedDateSlots(date, availableSchedule);
+      if (slots.length > 0) {
+        const firstSlot = slots[0];
+        setSelectedSlot(firstSlot);
+
+        setScheduleId(firstSlot.id);
+      } else {
+        setSelectedSlot(null);
+      }
+    },
+    [availableSchedule, getSelectedDateSlots],
+  );
+
+  const updateDateSelect = (date: Date | null) => {
+    setSelectedDate(date);
+    getFirstSlotOfDate(date);
+  };
+
+  const handleSlotSelect = (slot: TimeSlot) => {
+    setSelectedSlot(slot);
+    setScheduleId(slot.id);
+    // 폼 데이터 업데이트 slot.id -> scheduleId
+  };
+
+  const updateMonthChange = (newMonth: Date) => {
+    setCurrentDate(newMonth);
+  };
+
+  useEffect(() => {
+    // 데이터가 없을 경우
+    if (!availableSchedule) return;
+
+    // 디바이스 사이즈가 바뀌어 달력이 새로 렌더링 됐을 시 사용자가 이미 선택한 날짜가 있으면 그 날짜로 달력 세팅
+    if (currentDate === INITIAL_DATE && selectedDate) {
+      setCurrentDate(selectedDate);
+      updateDateSelect(selectedDate);
+      return;
+    }
+
+    // 아직 사용자가 날짜를 선택하지 않았을 때 예약 가능한 가장 빠른 날짜와 시간을 자동으로 선택
+    const firstActivityDate = getFirstActivityDateOfMonth(currentDate.getFullYear(), currentDate.getMonth());
+
+    if (firstActivityDate) {
+      updateDateSelect(new Date(firstActivityDate));
+    } else {
+      setSelectedDate(null);
+      setSelectedSlot(null);
+    }
+  }, [availableSchedule]);
+
+  return (
+    <div>
+      <Calendar
+        selectedDate={selectedDate}
+        updateDateSelect={updateDateSelect}
+        availableDates={availableDates}
+        updateMonthChange={updateMonthChange}
+        className="mx-auto mb-16 h-241 pt-[11px]"
+      />
+      <TimeSlotSelection
+        selectedDate={selectedDate}
+        selectedSlot={selectedSlot}
+        handleSlotSelect={handleSlotSelect}
+        availableSchedule={availableSchedule}
+        getSelectedDateSlots={getSelectedDateSlots}
+      />
+    </div>
+  );
+};
+
+export default ReservationScheduleSelect;

--- a/src/components/pages/ActivityDetails/activityInformation.tsx
+++ b/src/components/pages/ActivityDetails/activityInformation.tsx
@@ -1,7 +1,7 @@
 import FloatingBox from '@/components/common/FloatingBox';
 import { useActivityData } from '@/hooks/useActivityData';
 import useViewportSize from '@/hooks/useViewportSize';
-import { activityIdAtom } from '@/store/activityDetailsAtom';
+import { ReservationPriceAtom, activityIdAtom } from '@/store/activityDetailsAtom';
 import { useSetAtom } from 'jotai';
 
 import BannerImage from './bannerImage';
@@ -18,17 +18,20 @@ const ActivityInformation = ({ activityId = '2213' }: { activityId?: string }) =
   const isMobile = viewportSize === 'mobile';
   const isTablet = viewportSize === 'tablet';
 
+  const setPrice = useSetAtom(ReservationPriceAtom);
+
   const setActivityId = useSetAtom(activityIdAtom);
   setActivityId(activityId);
 
   const { activityData, isLoading, error } = useActivityData(activityId);
 
-
   if (isLoading) return <div>체험 상세 데이터 로딩중입니다...</div>;
   if (error) return <div>체험 상세 데이터를 불러오는데 실패했습니다.</div>;
   if (!activityData) return null;
 
-  const { category, title, rating, reviewCount, address, bannerImageUrl, description, subImages } = activityData;
+  const { category, title, rating, reviewCount, address, bannerImageUrl, description, subImages, price } = activityData;
+
+  setPrice(price);
 
   return (
     <>
@@ -41,7 +44,12 @@ const ActivityInformation = ({ activityId = '2213' }: { activityId?: string }) =
             <ActivityDescription description={description} />
             <KakaoMap address={address} />
           </div>
-          {!isMobile && (isTablet ? <FloatingBox.Tablet /> : <FloatingBox.Desktop activityId={activityId} />)}
+          {!isMobile &&
+            (isTablet ? (
+              <FloatingBox.Tablet />
+            ) : (
+              <FloatingBox.Desktop activityId={activityId} classNames="sticky top-0 w-[384px]" buttonLabel="예약하기" />
+            ))}
         </div>
         <ReviewList activityId={activityId} />
         {isMobile && (

--- a/src/components/pages/ActivityDetails/activityInformation.tsx
+++ b/src/components/pages/ActivityDetails/activityInformation.tsx
@@ -1,7 +1,7 @@
 import FloatingBox from '@/components/common/FloatingBox';
 import { useActivityData } from '@/hooks/useActivityData';
 import useViewportSize from '@/hooks/useViewportSize';
-import { ReservationPriceAtom, activityIdAtom } from '@/store/activityDetailsAtom';
+import { activityIdAtom, reservationPriceAtom } from '@/store/activityDetailsAtom';
 import { useSetAtom } from 'jotai';
 
 import BannerImage from './bannerImage';
@@ -18,7 +18,7 @@ const ActivityInformation = ({ activityId = '2213' }: { activityId?: string }) =
   const isMobile = viewportSize === 'mobile';
   const isTablet = viewportSize === 'tablet';
 
-  const setPrice = useSetAtom(ReservationPriceAtom);
+  const setPrice = useSetAtom(reservationPriceAtom);
 
   const setActivityId = useSetAtom(activityIdAtom);
   setActivityId(activityId);

--- a/src/components/pages/ActivityDetails/header.tsx
+++ b/src/components/pages/ActivityDetails/header.tsx
@@ -1,17 +1,25 @@
 import DropDown from '@/components/common/Dropdown';
 import { HeaderProps } from '@/types/activity';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 
 const Header = ({ category, title, rating, reviewCount, address }: HeaderProps) => {
   const [isOpenDropdown, setIsOpenDropdown] = useState(false);
 
+  const router = useRouter();
+
   const handleDropdownVisible = () => {
     setIsOpenDropdown((prev) => !prev);
   };
 
-  const handleOptionClick = (label: string) => {
-    console.log(label); // 여기에 드롭다운 메뉴 클릭 시 실행할 로직을 추가하세요
+  const handleOptionClick = (option: string) => {
+    if (option === '수정하기') {
+      router.push(`/my-page/activity-settings`);
+    }
+    if (option === '삭제하기') {
+      console.log('삭제하기'); // TODO: 삭제하기 기능 추가 예정
+    }
     setIsOpenDropdown(false);
   };
 
@@ -31,8 +39,18 @@ const Header = ({ category, title, rating, reviewCount, address }: HeaderProps) 
         />
         {isOpenDropdown && (
           <DropDown classNames="h-max w-120 right-0 top-48 z-50 ">
-            <DropDown.Option className="" key="수정하기" handleOptionClick={handleOptionClick} label="수정하기" />
-            <DropDown.Option className="" key="삭제하기" handleOptionClick={handleOptionClick} label="삭제하기" />
+            <DropDown.Option
+              className=""
+              key="수정하기"
+              handleOptionClick={() => handleOptionClick('수정하기')}
+              label="수정하기"
+            />
+            <DropDown.Option
+              className=""
+              key="삭제하기"
+              handleOptionClick={() => handleOptionClick('삭제하기')}
+              label="삭제하기"
+            />
           </DropDown>
         )}
       </div>

--- a/src/hooks/useReservationMutation.ts
+++ b/src/hooks/useReservationMutation.ts
@@ -6,15 +6,15 @@ export const useActivityReservationMutation = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: ({ activityId, formSubmitData }: { activityId: string; formSubmitData: formSubmitDataAtomType }) =>
-      postActivityReservation({ activityId, formSubmitData }),
+    mutationFn: ({ activityId, scheduleId, headCount }: formSubmitDataAtomType) =>
+      postActivityReservation({ activityId, scheduleId, headCount }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['reservation'] });
     },
   });
 
-  const submitReservation = (activityId: string, formSubmitData: formSubmitDataAtomType) => {
-    mutation.mutate({ activityId, formSubmitData });
+  const submitReservation = ({ activityId, scheduleId, headCount }: formSubmitDataAtomType) => {
+    mutation.mutate({ activityId, scheduleId, headCount });
   };
 
   return { submitReservation, ...mutation };

--- a/src/store/activityDetailsAtom.ts
+++ b/src/store/activityDetailsAtom.ts
@@ -9,7 +9,7 @@ export const headCountAtom = atom(0);
 
 export const activityIdAtom = atom('');
 
-export const ReservationPriceAtom = atom(0);
+export const reservationPriceAtom = atom(0);
 
 export const selectedDateAtom = atom<Date | null>(null);
 

--- a/src/store/activityDetailsAtom.ts
+++ b/src/store/activityDetailsAtom.ts
@@ -1,15 +1,20 @@
+import { TimeSlot } from '@/types/availableSchedulesTypes';
 import { atom } from 'jotai';
 
-export type formSubmitDataAtomType = { scheduleId: number; headCount: number };
+export type formSubmitDataAtomType = { activityId: string; scheduleId: number; headCount: number };
 
-export const formSubmitDataAtom = atom({ scheduleId: 0, headCount: 0 });
+export const scheduleIdAtom = atom(0);
+
+export const headCountAtom = atom(0);
 
 export const activityIdAtom = atom('');
 
-const INITIAL_DATE = new Date();
+export const ReservationPriceAtom = atom(0);
 
-const year = INITIAL_DATE.getFullYear();
-const twoDigitMonth = String(INITIAL_DATE.getMonth() + 1).padStart(2, '0');
+export const selectedDateAtom = atom<Date | null>(null);
 
-export const yearAtom = atom(year);
-export const monthAtom = atom(twoDigitMonth);
+export const selectedSlotAtom = atom<TimeSlot | null>(null);
+
+export const selectedScheduleStateAtom = atom(false);
+
+export const isModalOpenAtom = atom(false);


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

- FP-76

## ✅ 작업 사항
- 데스크탑 사이즈에서 일정 선택 후 화면 크기 테블릿, 모바일로 줄였을 때 선택한 일정 정보가 사라지는 부분 수정했습니다

- 예약 가능한 시간을 설정하는 부분이 원래 ⤵️
- 테블릿 -> DateSelect/TimeSlotSelection
- 데스크탑 -> DesktopComponents/TimeSlotSelection
- 이렇게 두개로 나뉘어져 있었는데 로직 자체가 아예 똑같아서 하나로 합쳐야겠다 판단하여 일단 DesktopComponents/TimeSlotSelection 으로 통일해놓은 상태입니다

- Desktop 캘린더 컴포넌트와 테블릿, 모바일에서 사용하는 DateSelectModal 캘린더 모달 컴포넌트 또한 로직 자체가 동일하여 하나로 합쳐야겠다 판단했습니다
<details>
  <summary>기존</summary>
<img width="387" alt="image" src="https://github.com/user-attachments/assets/02cfbe11-6e04-4c08-9648-a86297505ff7">
<img width="387" alt="image" src="https://github.com/user-attachments/assets/b2290e58-27ed-44ec-aaa9-07d8db0aa954">
</details>
<details>
  <summary>변경 후</summary>
<img width="399" alt="image" src="https://github.com/user-attachments/assets/b560ea64-1637-408c-96c6-79d345383da6">
<img width="394" alt="image" src="https://github.com/user-attachments/assets/b26d6660-38a5-4f28-a385-85959a175401">
</details>

- 사진과 같이 파란색 박스의 ReservationScheduleSelect 컴포넌트 생성 후 Calendar, TimeSlotSelection을 묶었습니다 
- 그래서 Desktop 캘린더 컴포넌트와 테블릿, 모바일에서 사용하는 DateSelectModal 캘린더 컴포넌트의 동일한 로직을 합쳤습니다
- 시간 선택 부분은 DesktopComponents/TimeSlotSelection컴포넌트로 통합했습니다 


## 👩‍💻 공유 포인트 및 논의 사항
