### PR TITLE
Refactor: 예약 내역 페이지 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query-devtools": "^5.51.11",
         "axios": "^1.7.2",
         "date-fns": "^3.6.0",
+        "framer-motion": "^11.3.29",
         "jira-prepare-commit-msg": "^1.7.2",
         "jotai": "^2.9.1",
         "next": "^14.2.5",
@@ -10318,6 +10319,31 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.3.29",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.29.tgz",
+      "integrity": "sha512-uyDuUOeOElJEA3kbkbyoTNEf75Jih1EUg0ouLKYMlGDdt/LaJPmO+FyOGAGxM2HwKhHcAoKFNveR5A8peb7yhw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-datepicker": "^7.3.0",
         "react-dom": "^18",
         "react-hook-form": "^7.52.1",
+        "react-icons": "^5.3.0",
         "react-kakao-maps-sdk": "^1.1.27",
         "tailwind-scrollbar-hide": "^1.1.7",
         "webpack": "^5.93.0",
@@ -14489,6 +14490,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query-devtools": "^5.51.11",
     "axios": "^1.7.2",
     "date-fns": "^3.6.0",
+    "framer-motion": "^11.3.29",
     "jira-prepare-commit-msg": "^1.7.2",
     "jotai": "^2.9.1",
     "next": "^14.2.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-datepicker": "^7.3.0",
     "react-dom": "^18",
     "react-hook-form": "^7.52.1",
+    "react-icons": "^5.3.0",
     "react-kakao-maps-sdk": "^1.1.27",
     "tailwind-scrollbar-hide": "^1.1.7",
     "webpack": "^5.93.0",

--- a/src/components/common/Animation/AnimatedContainer.tsx
+++ b/src/components/common/Animation/AnimatedContainer.tsx
@@ -1,0 +1,27 @@
+import { MotionProps, motion } from 'framer-motion';
+
+interface AnimatedContainerProps extends MotionProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const AnimatedContainer: React.FC<AnimatedContainerProps> = ({ children, className, ...motionProps }) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{
+        duration: 0.6,
+        ease: 'easeOut',
+        opacity: { duration: 0.5 },
+        x: { duration: 0.5, delay: 0.1 },
+      }}
+      className={className}
+      {...motionProps}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default AnimatedContainer;

--- a/src/components/common/Cards/components/cardItem.tsx
+++ b/src/components/common/Cards/components/cardItem.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion';
 import { Children, ReactNode, isValidElement } from 'react';
 
 import { CardBodyType } from './cardBody';
@@ -31,7 +32,11 @@ const CardItem = ({ contentsClassNames, children }: { contentsClassNames?: strin
   const cardFooter = getTypedChildren(CardFooterType, children);
 
   return (
-    <li className="flex w-344 rounded-24 bg-gray-100 shadow-modal md:w-429 lg:w-792">
+    <motion.li
+      whileHover={{ scale: 1.03 }}
+      transition={{ duration: 0.2 }}
+      className="flex w-344 rounded-24 bg-gray-100 shadow-modal md:w-429 lg:w-792"
+    >
       {cardImage}
       <div
         className={
@@ -44,7 +49,7 @@ const CardItem = ({ contentsClassNames, children }: { contentsClassNames?: strin
         {cardBody}
         {cardFooter}
       </div>
-    </li>
+    </motion.li>
   );
 };
 

--- a/src/components/common/Cards/reservationCard.tsx
+++ b/src/components/common/Cards/reservationCard.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { MyReservation } from '@/apis/myPage/myReservations.types';
 import Card from '@/components/common/Cards/components';
-import { completedReviewsAtom } from '@/store/completedReviewAtom';
 import { modalAtom } from '@/store/modalAtom';
 import { reservationIdAtom } from '@/store/reservationIdAtom';
 import { StatusType, getButtonInfo, getCardStatus } from '@/utils/cardStatus';
@@ -9,19 +8,26 @@ import { formatPrice } from '@/utils/formatPrice';
 import { useAtom, useSetAtom } from 'jotai';
 
 const ReservationCard = ({ myReservationData }: { myReservationData: MyReservation }) => {
-  const [modalType, setModalType] = useAtom(modalAtom);
+  const [, setModalType] = useAtom(modalAtom);
   const setReservationId = useSetAtom(reservationIdAtom);
-  const [completedReviews] = useAtom(completedReviewsAtom);
 
-  const { id: reservationId, activity, status, totalPrice, headCount, date, startTime, endTime } = myReservationData;
+  const {
+    id: reservationId,
+    activity,
+    status,
+    totalPrice,
+    headCount,
+    date,
+    startTime,
+    endTime,
+    reviewSubmitted,
+  } = myReservationData;
   const { id: activityId, bannerImageUrl, title } = activity;
   const { text: statusText, colorClass } = getCardStatus(status as StatusType);
   const { name: buttonName, action } = getButtonInfo(status as StatusType);
 
-  const isReviewCompleted = completedReviews.includes(reservationId);
-
   const handleButtonClick = () => {
-    if (action !== null && !isReviewCompleted) {
+    if (action !== null) {
       setReservationId(reservationId);
       setModalType(action);
     }
@@ -34,7 +40,7 @@ const ReservationCard = ({ myReservationData }: { myReservationData: MyReservati
         <Card.Header ClassNames={`${colorClass} text-md-bold md:text-lg-bold `} text={statusText} />
         <Card.Title title={title} />
         <Card.Body text={`${date} · ${startTime} - ${endTime} · ${headCount}명`} />
-        {!isReviewCompleted ? (
+        {reviewSubmitted === false ? (
           <Card.Footer
             text={formatPrice(totalPrice)}
             status={status}

--- a/src/components/common/Modal/Overlay/index.tsx
+++ b/src/components/common/Modal/Overlay/index.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useState } from 'react';
+import { MouseEvent, ReactNode, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 interface ModalOverlayProps {
   isOpen: boolean;
   onClose: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const ModalOverlay = ({ isOpen, onClose, children }: ModalOverlayProps) => {
   const [isBrowser, setIsBrowser] = useState(false);
 
-  const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleBackgroundClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
       onClose();
     }

--- a/src/components/common/Modal/Overlay/index.tsx
+++ b/src/components/common/Modal/Overlay/index.tsx
@@ -1,9 +1,64 @@
+import { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+
 interface ModalOverlayProps {
+  isOpen: boolean;
+  onClose: () => void;
   children: React.ReactNode;
 }
 
-const ModalOverlay = ({ children }: ModalOverlayProps) => {
-  return <div className="fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">{children}</div>;
+const ModalOverlay = ({ isOpen, onClose, children }: ModalOverlayProps) => {
+  const [isBrowser, setIsBrowser] = useState(false);
+
+  const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const getScrollbarWidth = () => {
+    return window.innerWidth - document.documentElement.clientWidth;
+  };
+
+  useEffect(() => {
+    setIsBrowser(true);
+  }, []);
+
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    const scrollbarWidth = getScrollbarWidth();
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscKey);
+      document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+      document.body.style.overflow = 'unset';
+      document.body.style.paddingRight = '0px';
+    };
+  }, [isOpen, onClose]);
+
+  if (!isBrowser || !isOpen) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(
+    <div
+      onClick={handleBackgroundClick}
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black bg-opacity-50"
+    >
+      {children}
+    </div>,
+    document.getElementById('modal-root') as HTMLElement,
+  );
 };
 
 export default ModalOverlay;

--- a/src/components/common/Modal/Overlay/index.tsx
+++ b/src/components/common/Modal/Overlay/index.tsx
@@ -2,7 +2,7 @@ import { MouseEvent, ReactNode, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 interface ModalOverlayProps {
-  isOpen: boolean;
+  isOpen: boolean | string | null;
   onClose: () => void;
   children: ReactNode;
 }

--- a/src/components/common/Modal/Review/hook/usePostReviewMutataion.ts
+++ b/src/components/common/Modal/Review/hook/usePostReviewMutataion.ts
@@ -13,7 +13,7 @@ export const usePostReviewMutation = () => {
     mutationFn: ({ reservationId, reviewData }: { reservationId: number | null; reviewData: ReviewData }) =>
       postReview(reservationId, reviewData),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['reviews'] });
+      queryClient.invalidateQueries({ queryKey: ['myReservations'] });
     },
     onError: (error) => {
       console.error('Post review error:', error);

--- a/src/components/common/Modal/Review/index.tsx
+++ b/src/components/common/Modal/Review/index.tsx
@@ -1,4 +1,3 @@
-import { completedReviewsAtom } from '@/store/completedReviewAtom';
 import { modalAtom } from '@/store/modalAtom';
 import { reservationIdAtom } from '@/store/reservationIdAtom';
 import { reviewDataProps } from '@/types/reviewModalTypes';
@@ -15,23 +14,22 @@ const Review = ({ title, bannerImageUrl, date, startTime, endTime, totalPrice, h
   const [content, setContent] = useState('');
   const [, setModalType] = useAtom(modalAtom);
   const reservationId = useAtomValue(reservationIdAtom);
-  const [, setCompletedReviews] = useAtom(completedReviewsAtom);
   const { mutate: postReviewData, error: postReviewError } = usePostReviewMutation();
 
   const handleSubmit = () => {
-    if (rating > 0 && content.trim() && reservationId !== null) {
+    if (rating > 0 && content.trim()) {
       postReviewData(
         { reservationId, reviewData: { rating, content } },
         {
           onSuccess: () => {
             setModalType(null);
-            setCompletedReviews((prev) => [...prev, reservationId]);
           },
         },
       );
     }
   };
 
+  console.log(reservationId);
   return (
     <>
       {postReviewError && <div className="mb-4 text-red-500">{postReviewError.message}</div>}

--- a/src/components/common/Modal/Review/index.tsx
+++ b/src/components/common/Modal/Review/index.tsx
@@ -29,7 +29,6 @@ const Review = ({ title, bannerImageUrl, date, startTime, endTime, totalPrice, h
     }
   };
 
-  console.log(reservationId);
   return (
     <>
       {postReviewError && <div className="mb-4 text-red-500">{postReviewError.message}</div>}

--- a/src/components/common/NavBar/index.tsx
+++ b/src/components/common/NavBar/index.tsx
@@ -1,7 +1,6 @@
 import { getUserProfile } from '@/apis/myPage/myProfile';
 import Modal from '@/components/common/Modal';
 import { useSignout } from '@/components/pages/auth/useSignout';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { tokenAtom } from '@/store/tokenAtom';
 import { userAtom } from '@/store/userAtom';
 import { useAtom } from 'jotai';
@@ -75,8 +74,6 @@ function NavBar({ accessToken }: { accessToken?: boolean }) {
     setToken(null);
   };
 
-  const modalRef = useClickOutside(handleModalClose);
-
   return (
     <div className="fixed left-0 right-0 top-0 z-10 border-b border-solid border-gray-300 bg-white">
       <div className="flex h-70 items-center justify-between p-20 lg:mx-auto lg:max-w-[1200px]">
@@ -123,13 +120,9 @@ function NavBar({ accessToken }: { accessToken?: boolean }) {
         )}
       </div>
 
-      {showLogoutModal && (
-        <Modal.Overlay>
-          <div ref={modalRef}>
-            <Modal.RegisterConfirm onClose={handleModalClose}>로그아웃 되었습니다!</Modal.RegisterConfirm>
-          </div>
-        </Modal.Overlay>
-      )}
+      <Modal.Overlay isOpen={showLogoutModal} onClose={handleModalClose}>
+        <Modal.RegisterConfirm onClose={handleModalClose}>로그아웃 되었습니다!</Modal.RegisterConfirm>
+      </Modal.Overlay>
     </div>
   );
 }

--- a/src/components/common/SideNavMenu/sideNavMenuOptionList.tsx
+++ b/src/components/common/SideNavMenu/sideNavMenuOptionList.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
@@ -31,9 +32,15 @@ const SideNavMenuOptionList = () => {
   return (
     <div className="flex w-296 flex-col gap-8 md:w-203 lg:w-336">
       {menuOptionList.map((option) => (
-        <ul key={option.id} onClick={() => handleOptionClick(option.path)}>
+        <motion.ul
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          transition={{ duration: 0.2 }}
+          key={option.id}
+          onClick={() => handleOptionClick(option.path)}
+        >
           <SideNavMenuOption imgSrc={option.imgSrc} text={option.text} isActive={activeOption === option.id} />
-        </ul>
+        </motion.ul>
       ))}
     </div>
   );

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -23,7 +23,7 @@ const getToastIcon = (type?: ToastType) => {
   }
 };
 
-const TOAST_DURATION = 2000;
+const TOAST_DURATION = 3000;
 const ANIMATION_DURATION = 300;
 
 const Toast: React.FC<ToastProps> = ({ type, message = '테스트 메세지입니다.', id }) => {
@@ -44,7 +44,9 @@ const Toast: React.FC<ToastProps> = ({ type, message = '테스트 메세지입�
 
   return (
     <div
-      className={`fixed left-1/2 top-24 inline-flex w-300 -translate-x-1/2 items-center rounded-lg px-24 py-16 transition-all duration-300 ease-in-out md:bottom-24 md:left-auto md:right-24 md:top-auto md:max-w-none md:translate-x-0 ${type === 'success' ? 'bg-green-200' : 'bg-red-500'} ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'} `}
+      className={`fixed bottom-24 right-24 inline-flex w-300 items-center rounded-lg px-24 py-16 transition-all duration-300 ease-in-out ${
+        type === 'success' ? 'bg-green-200' : 'bg-red-500'
+      } ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'}`}
     >
       <div className="mr-10 text-white">{getToastIcon(type)}</div>
       <div className="inline-flex h-full w-full items-center justify-center text-sm font-semibold text-white">

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -1,0 +1,57 @@
+import { removeToastAtom } from '@/store/toastsAtom';
+import { useSetAtom } from 'jotai';
+import React, { useEffect, useState } from 'react';
+import { IoCheckmarkCircle } from 'react-icons/io5';
+import { MdError } from 'react-icons/md';
+
+export type ToastType = 'success' | 'error';
+
+export interface ToastProps {
+  type?: ToastType;
+  message?: string;
+  id: string;
+}
+
+const getToastIcon = (type?: ToastType) => {
+  switch (type) {
+    case 'success':
+      return <IoCheckmarkCircle />;
+    case 'error':
+      return <MdError />;
+    default:
+      return null;
+  }
+};
+
+const TOAST_DURATION = 2000;
+const ANIMATION_DURATION = 300;
+
+const Toast: React.FC<ToastProps> = ({ type, message = '테스트 메세지입니다.', id }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const removeToastItem = useSetAtom(removeToastAtom);
+
+  useEffect(() => {
+    const showTimeout = setTimeout(() => setIsVisible(true), 100);
+    const hideTimeout = setTimeout(() => setIsVisible(false), TOAST_DURATION);
+    const removeTimeout = setTimeout(() => removeToastItem(id), TOAST_DURATION + ANIMATION_DURATION);
+
+    return () => {
+      clearTimeout(showTimeout);
+      clearTimeout(hideTimeout);
+      clearTimeout(removeTimeout);
+    };
+  }, [id, removeToastItem]);
+
+  return (
+    <div
+      className={`fixed left-1/2 top-24 inline-flex w-300 -translate-x-1/2 items-center rounded-lg px-24 py-16 transition-all duration-300 ease-in-out md:bottom-24 md:left-auto md:right-24 md:top-auto md:max-w-none md:translate-x-0 ${type === 'success' ? 'bg-green-200' : 'bg-red-500'} ${isVisible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'} `}
+    >
+      <div className="mr-10 text-white">{getToastIcon(type)}</div>
+      <div className="inline-flex h-full w-full items-center justify-center text-sm font-semibold text-white">
+        {message}
+      </div>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/common/Toast/toastProvider.tsx
+++ b/src/components/common/Toast/toastProvider.tsx
@@ -1,0 +1,27 @@
+import Toast from '@/components/common/Toast';
+import { toastsAtom } from '@/store/toastsAtom';
+import { useAtomValue } from 'jotai';
+import { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+
+const ToastProvider = () => {
+  const [isBrowser, setIsBrowser] = useState(false);
+  const toasts = useAtomValue(toastsAtom);
+
+  useEffect(() => {
+    setIsBrowser(true);
+  }, []);
+
+  if (!isBrowser) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(
+    <div className="absolute left-1/2 top-5 flex -translate-x-1/2 flex-col items-center gap-5">
+      {toasts?.map((toast) => <Toast key={toast.id} {...toast} />)}
+    </div>,
+    document.getElementById('toast-root') as HTMLElement,
+  );
+};
+
+export default ToastProvider;

--- a/src/components/common/Toast/toastProvider.tsx
+++ b/src/components/common/Toast/toastProvider.tsx
@@ -17,7 +17,7 @@ const ToastProvider = () => {
   }
 
   return ReactDOM.createPortal(
-    <div className="absolute left-1/2 top-5 flex -translate-x-1/2 flex-col items-center gap-5">
+    <div className="fixed bottom-0 right-0 flex flex-col items-end gap-5 p-5">
       {toasts?.map((toast) => <Toast key={toast.id} {...toast} />)}
     </div>,
     document.getElementById('toast-root') as HTMLElement,

--- a/src/components/pages/ActivityDetails/activityInformation.tsx
+++ b/src/components/pages/ActivityDetails/activityInformation.tsx
@@ -1,9 +1,7 @@
 import { useMyInformation } from '@/apis/ActivityDetailsPage/getMyInformation';
 import FloatingBox from '@/components/common/FloatingBox';
 import Modal from '@/components/common/Modal';
-import ModalOverlay from '@/components/common/Modal/Overlay';
 import { useReservationSubmit } from '@/components/pages/ActivityDetails/useReservationSubmit';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import useViewportSize from '@/hooks/useViewportSize';
 import { activityIdAtom, reservationPriceAtom } from '@/store/activityDetailsAtom';
 import { Activity } from '@/types/activity';
@@ -51,8 +49,6 @@ const ActivityInformation = ({
     handleDeleteConfirmation,
     modalMessage,
   } = useReservationSubmit();
-
-  const modalRef = useClickOutside(handleCloseModal);
 
   const { userInformationData, isLoading: isLoadingUserData, error } = useMyInformation();
 
@@ -107,19 +103,17 @@ const ActivityInformation = ({
           </div>
         )}
         {isModalOpen && (
-          <ModalOverlay>
-            <div ref={modalRef}>
-              <Modal.RegisterConfirm
-                onClose={isDeleteConfirmation ? handleDeleteActivity : handleCloseModal}
-                onCancel={handleCloseModal}
-                countdown={countdown}
-                showCountdown={showCountdown}
-                showCancelButton={isDeleteConfirmation}
-              >
-                {modalMessage}
-              </Modal.RegisterConfirm>
-            </div>
-          </ModalOverlay>
+          <Modal.Overlay isOpen={isModalOpen} onClose={isDeleteConfirmation ? handleDeleteActivity : handleCloseModal}>
+            <Modal.RegisterConfirm
+              onClose={isDeleteConfirmation ? handleDeleteActivity : handleCloseModal}
+              onCancel={handleCloseModal}
+              countdown={countdown}
+              showCountdown={showCountdown}
+              showCancelButton={isDeleteConfirmation}
+            >
+              {modalMessage}
+            </Modal.RegisterConfirm>
+          </Modal.Overlay>
         )}
         <ScrollToTopButton />
       </div>

--- a/src/components/pages/auth/signInForm.tsx
+++ b/src/components/pages/auth/signInForm.tsx
@@ -1,7 +1,6 @@
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
 import Modal from '@/components/common/Modal';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { SigninData } from '@/types/auth';
 import { signinValidationSchema } from '@/utils/schema';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -28,8 +27,6 @@ const SignInForm = () => {
   const handleModalClose = () => {
     resetError();
   };
-
-  const modalRef = useClickOutside(handleModalClose);
 
   return (
     <>
@@ -61,13 +58,9 @@ const SignInForm = () => {
         </Button.Default>
       </form>
 
-      {error && (
-        <Modal.Overlay>
-          <div ref={modalRef}>
-            <Modal.RegisterConfirm onClose={handleModalClose}>{error}</Modal.RegisterConfirm>
-          </div>
-        </Modal.Overlay>
-      )}
+      <Modal.Overlay onClose={handleModalClose} isOpen={error}>
+        <Modal.RegisterConfirm onClose={handleModalClose}>{error}</Modal.RegisterConfirm>
+      </Modal.Overlay>
     </>
   );
 };

--- a/src/components/pages/auth/signupForm.tsx
+++ b/src/components/pages/auth/signupForm.tsx
@@ -2,7 +2,6 @@ import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
 import Modal from '@/components/common/Modal';
 import SuccessMessages from '@/constants/successMessages';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { useToggle } from '@/hooks/useToggle';
 import { SignupFormData } from '@/types/auth';
 import { signupValidationSchema } from '@/utils/schema';
@@ -38,8 +37,6 @@ const SignupForm = () => {
       router.push('/signin');
     }
   };
-
-  const modalRef = useClickOutside(handleModalClose);
 
   return (
     <>
@@ -96,15 +93,11 @@ const SignupForm = () => {
           {isLoading ? '처리 중...' : '회원가입 하기'}
         </Button.Default>
       </form>
-      {isModalOpen && (
-        <Modal.Overlay>
-          <div ref={modalRef}>
-            <Modal.RegisterConfirm onClose={handleModalClose}>
-              {isSuccess ? SuccessMessages.SIGNUP_SUCCESS : error}
-            </Modal.RegisterConfirm>
-          </div>
-        </Modal.Overlay>
-      )}
+      <Modal.Overlay onClose={handleModalClose} isOpen={isModalOpen}>
+        <Modal.RegisterConfirm onClose={handleModalClose}>
+          {isSuccess ? SuccessMessages.SIGNUP_SUCCESS : error}
+        </Modal.RegisterConfirm>
+      </Modal.Overlay>
     </>
   );
 };

--- a/src/components/pages/myPage/ActivitySettings/activitySettingsContent.tsx
+++ b/src/components/pages/myPage/ActivitySettings/activitySettingsContent.tsx
@@ -21,7 +21,7 @@ const ActivitySettingsContent = ({ activitiesData, isEmpty = false }: ActivitySe
         </Button.Default>
       </div>
       {isEmpty ? (
-        <div className="md:w-429 lg:w-792">
+        <div className="mb-420 md:mb-601 md:w-429 lg:mb-[469px] lg:w-792">
           <EmptyContent />
         </div>
       ) : (

--- a/src/components/pages/myPage/RegistActivity/registActivityContent.tsx
+++ b/src/components/pages/myPage/RegistActivity/registActivityContent.tsx
@@ -4,7 +4,6 @@ import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
 import Modal from '@/components/common/Modal';
 import TextArea from '@/components/common/TextArea';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { formatNumber, isNumber, unformatNumber } from '@/utils/formatNumber';
 import { registActivitySchema } from '@/utils/schema';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -43,7 +42,6 @@ const RegistActivityContent = ({ activityId }: RegistActivityContentProps) => {
   const [initialSchedules, setInitialSchedules] = useState<Schedule[]>([]);
   const [scheduleIdsToRemove, setScheduleIdsToRemove] = useState<number[]>([]);
   const [schedulesToAdd, setSchedulesToAdd] = useState<Schedule[]>([]);
-  const modalRef = useClickOutside(() => setIsModalOpen(false));
   const isEditMode = !!activityId;
 
   const {
@@ -285,15 +283,11 @@ const RegistActivityContent = ({ activityId }: RegistActivityContentProps) => {
           <p className="text-2lg-regular text-gray-800">*이미지는 최대 4개까지 등록 가능합니다</p>
         </div>
       </form>
-      {isModalOpen && (
-        <Modal.Overlay>
-          <div ref={modalRef} className="h-full md:h-auto md:w-auto">
-            <Modal.RegisterConfirm onClose={handleCloseModal}>
-              {`체험 ${isEditMode ? '수정' : '등록'}이 완료되었습니다.`}
-            </Modal.RegisterConfirm>
-          </div>
-        </Modal.Overlay>
-      )}
+      <Modal.Overlay isOpen={isModalOpen} onClose={handleCloseModal}>
+        <Modal.RegisterConfirm onClose={handleCloseModal}>
+          {`체험 ${isEditMode ? '수정' : '등록'}이 완료되었습니다.`}
+        </Modal.RegisterConfirm>
+      </Modal.Overlay>
     </>
   );
 };

--- a/src/components/pages/myPage/ReservationList/hooks/useMyReservationsQuery.ts
+++ b/src/components/pages/myPage/ReservationList/hooks/useMyReservationsQuery.ts
@@ -1,15 +1,19 @@
 import { getMyReservations } from '@/apis/myPage/myReservations';
 import { MyReservationResponse } from '@/apis/myPage/myReservations.types';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import useToast from '@/hooks/useToast';
 import { InfiniteData, useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { AxiosError, isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 
 export const useMyReservationsQuery = () => {
   const queryClient = useQueryClient();
   const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
+  const toast = useToast();
+
   const { fetchNextPage, hasNextPage, error, data, refetch } = useInfiniteQuery<
     MyReservationResponse,
-    Error,
+    AxiosError,
     InfiniteData<MyReservationResponse>,
     ['myReservations', string | null],
     number | null
@@ -39,6 +43,20 @@ export const useMyReservationsQuery = () => {
       queryClient.removeQueries({ queryKey: ['myReservations'] });
     };
   }, [refetch, queryClient]);
+
+  useEffect(() => {
+    if (error) {
+      if (isAxiosError(error)) {
+        if (error.response?.status === 401) {
+          toast.error('인증에 실패했습니다. 다시 로그인해주세요.');
+        } else {
+          toast.error(error.message || '예약 정보를 불러오는 데 실패했습니다.');
+        }
+      } else {
+        toast.error('알 수 없는 오류가 발생했습니다.');
+      }
+    }
+  }, [error, toast]);
 
   return {
     myReservationsData,

--- a/src/components/pages/myPage/ReservationList/reservationContent.tsx
+++ b/src/components/pages/myPage/ReservationList/reservationContent.tsx
@@ -28,7 +28,7 @@ const ReservationContent = ({
         {showFilter && <Filter content="필터" onOptionSelect={onStatusChange} selectedOption={selectedStatus} />}
       </div>
       {isEmptyMyReservationData ? (
-        <div className="md:w-429 lg:w-792">
+        <div className="mb-420 md:mb-601 md:w-429 lg:mb-[469px] lg:w-792">
           <EmptyContent />
         </div>
       ) : (

--- a/src/components/pages/myPage/Schedule/mySchedule.tsx
+++ b/src/components/pages/myPage/Schedule/mySchedule.tsx
@@ -75,40 +75,40 @@ const MySchedule = () => {
 
   return (
     <div>
-      <div className="mb-60 ml-auto mr-auto mt-30 w-343 md:mr-0 md:w-430 lg:w-800">
-        <div className="flex items-center">
-          <div className="block cursor-pointer md:hidden" onClick={handleGoMyPage}>
-            <LeftArrow />
-          </div>
-          <h2 className="ml-10 mt-5 text-3xl-bold md:ml-0">예약 현황</h2>
+      <div className="flex items-center">
+        <div className="block cursor-pointer md:hidden" onClick={handleGoMyPage}>
+          <LeftArrow />
         </div>
-        {hasExperiences ? (
-          <div className="relative mb-20 mt-20">
-            <div className="absolute z-10 ml-10 h-24 w-45 -translate-y-2.5 transform bg-white text-center text-md-regular">
-              체험명
-            </div>
-            <Input.Dropdown
-              options={activities}
-              defaultOption={selectedOption ? selectedOption.label : '내 체험을 선택하세요'}
-              onSelect={handleOptionSelect}
-              className="h-56"
-            />
-          </div>
-        ) : (
-          <div className="mb-50 mt-100 flex justify-center">
-            <Paper />
-          </div>
-        )}
-        {hasExperiences ? (
-          <Calendar
-            activityId={parseInt(selectedOption?.value ?? '0', 10)}
-            reservations={reservations}
-            onMonthChange={handleMonthChange}
-          />
-        ) : (
-          <div className="mb-200 text-center text-2xl-medium text-gray-700">아직 등록한 체험이 없어요</div>
-        )}
+        <h2 className="ml-10 text-3xl-bold md:ml-0">예약 현황</h2>
       </div>
+      {hasExperiences ? (
+        <div className="relative mb-20 mt-20">
+          <div className="absolute z-10 ml-10 h-24 w-45 -translate-y-2.5 transform bg-white text-center text-md-regular">
+            체험명
+          </div>
+          <Input.Dropdown
+            options={activities}
+            defaultOption={selectedOption ? selectedOption.label : '내 체험을 선택하세요'}
+            onSelect={handleOptionSelect}
+            className="h-56"
+          />
+        </div>
+      ) : (
+        <div className="mb-50 mt-100 flex justify-center">
+          <Paper />
+        </div>
+      )}
+      {hasExperiences ? (
+        <Calendar
+          activityId={parseInt(selectedOption?.value ?? '0', 10)}
+          reservations={reservations}
+          onMonthChange={handleMonthChange}
+        />
+      ) : (
+        <div className="mb-420 md:mb-601 mb-200 text-center text-2xl-medium text-gray-700 lg:mb-[469px]">
+          아직 등록한 체험이 없어요
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/pages/myPage/inputSection.tsx
+++ b/src/components/pages/myPage/inputSection.tsx
@@ -3,15 +3,14 @@ import Input from '@/components/common/Input';
 interface InputSectionProps {
   title: string;
   value?: string;
-  readonly?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const InputSection: React.FC<InputSectionProps> = ({ title, value, readonly, onChange }) => {
+const InputSection: React.FC<InputSectionProps> = ({ title, value, onChange }) => {
   return (
     <>
       <h3 className="mt-30 text-2xl-bold">{title}</h3>
-      <Input className="mt-20" placeholder="" defaultValue={value} readOnly={readonly} onChange={onChange} />
+      <Input className="mt-20" placeholder="" defaultValue={value} onChange={onChange} />
     </>
   );
 };

--- a/src/components/pages/myPage/inputSection.tsx
+++ b/src/components/pages/myPage/inputSection.tsx
@@ -3,14 +3,15 @@ import Input from '@/components/common/Input';
 interface InputSectionProps {
   title: string;
   value?: string;
+  readonly?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const InputSection: React.FC<InputSectionProps> = ({ title, value, onChange }) => {
+const InputSection: React.FC<InputSectionProps> = ({ title, value, readonly, onChange }) => {
   return (
     <>
       <h3 className="mt-30 text-2xl-bold">{title}</h3>
-      <Input className="mt-20" placeholder="" defaultValue={value} onChange={onChange} />
+      <Input className="mt-20" placeholder="" defaultValue={value} readOnly={readonly} onChange={onChange} />
     </>
   );
 };

--- a/src/components/pages/myPage/myProfile.tsx
+++ b/src/components/pages/myPage/myProfile.tsx
@@ -114,7 +114,7 @@ const MyProfile = () => {
             value={user.nickname}
             onChange={(e) => setUser({ ...user, nickname: e.target.value })}
           />
-          <InputSection title="이메일" value={user.email} />
+          <InputSection title="이메일" value={user.email} readonly={true} />
           <PasswordInputSection
             title="새 비밀번호"
             placeholder="8자 이상 입력해 주세요"

--- a/src/components/pages/myPage/myProfile.tsx
+++ b/src/components/pages/myPage/myProfile.tsx
@@ -86,16 +86,14 @@ const MyProfile = () => {
   const isSideNavbarOpen = viewportSize === 'tablet' || 'desktop';
 
   return (
-    <div className="bg-gray-100">
-      <div className="ml-auto mr-auto flex md:w-744 lg:w-1200">
-        <div className="ml-30 mt-30">
-          {isSideNavbarOpen && (
-            <div className="hidden w-60 bg-white md:block">
-              <SideNavMenu />
-            </div>
-          )}
-        </div>
-        <div className="mb-60 ml-auto mr-auto mt-30 w-343 md:mr-0 md:w-430 lg:w-750">
+    <div className="md:mb-363 l lg:mb-208 mb-168 mt-94 lg:mt-142">
+      <div className="mx-auto flex justify-between md:w-696 lg:w-1200">
+        {isSideNavbarOpen && (
+          <div className="hidden bg-white md:block">
+            <SideNavMenu />
+          </div>
+        )}
+        <div className="mx-auto mb-60 w-343 md:mx-0 md:w-429 lg:w-792">
           <div className="flex items-center justify-between">
             <div className="flex items-center">
               <div className="block cursor-pointer md:hidden" onClick={handleGoMyPage}>
@@ -116,7 +114,7 @@ const MyProfile = () => {
             value={user.nickname}
             onChange={(e) => setUser({ ...user, nickname: e.target.value })}
           />
-          <InputSection title="이메일" value={user.email} readonly={true} />
+          <InputSection title="이메일" value={user.email} />
           <PasswordInputSection
             title="새 비밀번호"
             placeholder="8자 이상 입력해 주세요"
@@ -135,11 +133,9 @@ const MyProfile = () => {
       </div>
 
       {/* 모달 조건부 렌더링 */}
-      {isModalOpen && (
-        <Modal.Overlay>
-          <Modal.RegisterConfirm onClose={handleModalClose}>{modalMessage}</Modal.RegisterConfirm>
-        </Modal.Overlay>
-      )}
+      <Modal.Overlay isOpen={isModalOpen} onClose={handleModalClose}>
+        <Modal.RegisterConfirm onClose={handleModalClose}>{modalMessage}</Modal.RegisterConfirm>
+      </Modal.Overlay>
     </div>
   );
 };

--- a/src/constants/registAcitivtyErrorMessages.js
+++ b/src/constants/registAcitivtyErrorMessages.js
@@ -8,7 +8,7 @@ const REGIST_ACTIVITY_ERROR_MESSAGES = {
   DATE_REQUIRED: '날짜를 선택해 주세요',
   MIN_TIME_SLOTS: '최소 1개의 시간대를 추가해 주세요',
   BANNER_IMAGE_REQUIRED: '배너 이미지를 1개 이상 등록해 주세요.',
-  INTRO_IMAGES_REQUIRED: '소개 이미지를 1개 이상 등록해 주세요.',
+  INTRO_IMAGES_REQUIRED: '소개 이미지는 정확히 4개를 등록해 주세요.',
 };
 
 export default REGIST_ACTIVITY_ERROR_MESSAGES;

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,13 @@
+import { toastAtom } from '@/store/toastsAtom';
+import { useSetAtom } from 'jotai';
+
+const useToast = () => {
+  const addToast = useSetAtom(toastAtom);
+
+  return {
+    success: addToast('success'),
+    error: addToast('error'),
+  };
+};
+
+export default useToast;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,8 +20,7 @@ const pretendard = localFont({
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const showNavBarAndFooter =
-    !['/signup', '/signin', '/my-page/reservation-list'].includes(router.pathname) &&
-    !router.pathname.startsWith('/my-page/regist-activity');
+    !['/signup', '/signin'].includes(router.pathname) && !router.pathname.startsWith('/my-page');
 
   return (
     <Provider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import Footer from '@/components/common/Footer';
 import NavBar from '@/components/common/NavBar';
+import ToastProvider from '@/components/common/Toast/toastProvider';
 import '@/styles/globals.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -29,6 +30,7 @@ export default function App({ Component, pageProps }: AppProps) {
           {showNavBarAndFooter && <NavBar />}
           <div id="notification-root" />
           <Component {...pageProps} />
+          <ToastProvider />
           {showNavBarAndFooter && <Footer />}
           <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,16 +4,18 @@ import Script from 'next/script';
 export default function Document() {
   return (
     <Html lang="ko">
-      <Head />
-      <body>
+      <Head>
         <Script
           src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.KAKAO_KEY}&libraries=services,clusterer&autoload=false`}
           strategy="beforeInteractive"
         />
         <Script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js" strategy="beforeInteractive" />
-        <div id="modal-root" />
+      </Head>
+      <body>
         <Main />
         <NextScript />
+        <div id="modal-root" />
+        <div id="toast-root" />
       </body>
     </Html>
   );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -11,6 +11,7 @@ export default function Document() {
           strategy="beforeInteractive"
         />
         <Script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js" strategy="beforeInteractive" />
+        <div id="modal-root" />
         <Main />
         <NextScript />
       </body>

--- a/src/pages/my-page/activity-settings.tsx
+++ b/src/pages/my-page/activity-settings.tsx
@@ -1,3 +1,5 @@
+import Footer from '@/components/common/Footer';
+import NavBar from '@/components/common/NavBar';
 import SideNavMenu from '@/components/common/SideNavMenu';
 import ActivitySettingsContent from '@/components/pages/myPage/ActivitySettings/activitySettingsContent';
 import { useActivitiesQuery } from '@/components/pages/myPage/ActivitySettings/hooks/useActivitiesQuery';
@@ -15,8 +17,9 @@ const ActivitySettings = () => {
 
   return (
     <>
-      {queryError && <div className="mb-4 text-red-500">{queryError.message}</div>}
-      <main className="mx-auto mb-86 mt-16 w-344 md:mb-94 md:mt-24 md:w-696 lg:mb-142 lg:mt-72 lg:w-1200">
+      <NavBar />
+      <main className="md:mb-400 lg:mb-270 mx-auto mb-[496px] mt-94 w-344 md:w-696 lg:mt-142 lg:w-1200">
+        {queryError && <div className="mb-4 text-red-500">{queryError.message}</div>}
         {isMobile && <ActivitySettingsContent activitiesData={activitiesData} isEmpty={isActivityEmpty} />}
         {(isTablet || isDesktop) && (
           <div className="flex justify-between">
@@ -26,6 +29,7 @@ const ActivitySettings = () => {
         )}
         <div ref={setTarget}></div>
       </main>
+      <Footer />
     </>
   );
 };

--- a/src/pages/my-page/index.tsx
+++ b/src/pages/my-page/index.tsx
@@ -7,11 +7,17 @@ const Mypage: React.FC = () => {
   const router = useRouter();
   const viewportSize = useViewportSize(); // 현재 화면 크기를 가져옴
 
+  const redirectPath = viewportSize !== 'mobile' && router.pathname === '/my-page';
+
   useEffect(() => {
-    if (viewportSize !== 'mobile' && router.pathname === '/my-page') {
+    if (redirectPath) {
       router.replace('/my-page/profile');
     }
-  }, [viewportSize, router]);
+  }, [redirectPath, router]);
+
+  if (redirectPath) {
+    return null;
+  }
 
   return (
     <div className="flex w-full justify-center bg-gray-100">

--- a/src/pages/my-page/profile.tsx
+++ b/src/pages/my-page/profile.tsx
@@ -1,9 +1,13 @@
+import Footer from '@/components/common/Footer';
+import NavBar from '@/components/common/NavBar';
 import MyProfile from '@/components/pages/myPage/myProfile';
 
 const Profile = () => {
   return (
     <div>
+      <NavBar />
       <MyProfile />
+      <Footer />
     </div>
   );
 };

--- a/src/pages/my-page/regist-activity/index.tsx
+++ b/src/pages/my-page/regist-activity/index.tsx
@@ -15,7 +15,7 @@ const RegistActivity = () => {
   return (
     <>
       <NavBar />
-      <main className="mx-auto mb-94 mt-94 w-343 md:w-696 lg:mb-142 lg:mt-142 lg:w-1200">
+      <main className="mx-auto mb-94 mt-24 w-343 md:w-696 lg:mb-142 lg:mt-72 lg:w-1200">
         {isMobile && <RegistActivityContent />}
         {(isTablet || isDesktop) && (
           <div className="flex justify-between">

--- a/src/pages/my-page/regist-activity/index.tsx
+++ b/src/pages/my-page/regist-activity/index.tsx
@@ -15,7 +15,7 @@ const RegistActivity = () => {
   return (
     <>
       <NavBar />
-      <main className="mx-auto mb-94 mt-24 w-343 md:w-696 lg:mb-142 lg:mt-72 lg:w-1200">
+      <main className="mx-auto mb-94 mt-94 w-343 md:w-696 lg:mb-142 lg:mt-142 lg:w-1200">
         {isMobile && <RegistActivityContent />}
         {(isTablet || isDesktop) && (
           <div className="flex justify-between">

--- a/src/pages/my-page/reservation-list.tsx
+++ b/src/pages/my-page/reservation-list.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-named-as-default-member */
 import AnimatedContainer from '@/components/common/Animation/AnimatedContainer';
 import Footer from '@/components/common/Footer';
 import Modal from '@/components/common/Modal';
@@ -17,14 +18,8 @@ const ReservationList = () => {
   const isTablet = deviceState === Device.TABLET;
   const isDesktop = deviceState === Device.DESKTOP;
 
-  const {
-    myReservationsData,
-    isMyReservationsEmpty,
-    error: queryError,
-    setTarget,
-    handleStatusChange,
-    selectedStatus,
-  } = useMyReservationsQuery();
+  const { myReservationsData, isMyReservationsEmpty, setTarget, handleStatusChange, selectedStatus } =
+    useMyReservationsQuery();
 
   const handleCloseModal = () => {
     setModalType(null);
@@ -35,7 +30,6 @@ const ReservationList = () => {
       <NavBar />
       <AnimatedContainer>
         <main className="md:mb-400 lg:mb-270 mx-auto mb-[496px] mt-94 w-344 md:w-696 lg:mb-142 lg:mt-142 lg:w-1200">
-          {queryError && <div className="mb-4 text-red-500">{queryError.message}</div>}
           {isMobile && (
             <div>
               <ReservationContent

--- a/src/pages/my-page/reservation-list.tsx
+++ b/src/pages/my-page/reservation-list.tsx
@@ -1,3 +1,4 @@
+import AnimatedContainer from '@/components/common/Animation/AnimatedContainer';
 import Footer from '@/components/common/Footer';
 import Modal from '@/components/common/Modal';
 import NavBar from '@/components/common/NavBar';
@@ -32,48 +33,50 @@ const ReservationList = () => {
   return (
     <>
       <NavBar />
-      <main className="md:mb-400 lg:mb-270 mx-auto mb-[496px] mt-94 w-344 md:w-696 lg:mb-142 lg:mt-142 lg:w-1200">
-        {queryError && <div className="mb-4 text-red-500">{queryError.message}</div>}
-        {isMobile && (
-          <div>
-            <ReservationContent
-              myReservationsData={myReservationsData}
-              isEmptyMyReservationData={isMyReservationsEmpty}
-              onStatusChange={handleStatusChange}
-              selectedStatus={selectedStatus}
-            />
-          </div>
-        )}
-        {(isTablet || isDesktop) && (
-          <div className="flex justify-between">
-            <SideNavMenu />
+      <AnimatedContainer>
+        <main className="md:mb-400 lg:mb-270 mx-auto mb-[496px] mt-94 w-344 md:w-696 lg:mb-142 lg:mt-142 lg:w-1200">
+          {queryError && <div className="mb-4 text-red-500">{queryError.message}</div>}
+          {isMobile && (
             <div>
               <ReservationContent
                 myReservationsData={myReservationsData}
-                showFilter={isDesktop}
                 isEmptyMyReservationData={isMyReservationsEmpty}
                 onStatusChange={handleStatusChange}
                 selectedStatus={selectedStatus}
               />
             </div>
-          </div>
-        )}
-        <Modal.Overlay isOpen={modalType !== null} onClose={handleCloseModal}>
-          {modalType === 'cancel' && <Modal.CancelConfirm />}
-          {modalType === 'review' && (
-            <Modal.Review
-              title="함께 배우면 즐거운 스트릿 댄스"
-              bannerImageUrl="/images/test-profile-img.png"
-              date="2023. 2. 14"
-              startTime="11:00"
-              endTime="12:30"
-              totalPrice={10000}
-              headCount={10}
-            />
           )}
-        </Modal.Overlay>
-        <div ref={setTarget}></div>
-      </main>
+          {(isTablet || isDesktop) && (
+            <div className="flex justify-between">
+              <SideNavMenu />
+              <div>
+                <ReservationContent
+                  myReservationsData={myReservationsData}
+                  showFilter={isDesktop}
+                  isEmptyMyReservationData={isMyReservationsEmpty}
+                  onStatusChange={handleStatusChange}
+                  selectedStatus={selectedStatus}
+                />
+              </div>
+            </div>
+          )}
+          <Modal.Overlay isOpen={modalType !== null} onClose={handleCloseModal}>
+            {modalType === 'cancel' && <Modal.CancelConfirm />}
+            {modalType === 'review' && (
+              <Modal.Review
+                title="함께 배우면 즐거운 스트릿 댄스"
+                bannerImageUrl="/images/test-profile-img.png"
+                date="2023. 2. 14"
+                startTime="11:00"
+                endTime="12:30"
+                totalPrice={10000}
+                headCount={10}
+              />
+            )}
+          </Modal.Overlay>
+          <div ref={setTarget}></div>
+        </main>
+      </AnimatedContainer>
       <Footer />
     </>
   );

--- a/src/pages/my-page/reservation-list.tsx
+++ b/src/pages/my-page/reservation-list.tsx
@@ -4,12 +4,10 @@ import NavBar from '@/components/common/NavBar';
 import SideNavMenu from '@/components/common/SideNavMenu';
 import { useMyReservationsQuery } from '@/components/pages/myPage/ReservationList/hooks/useMyReservationsQuery';
 import ReservationContent from '@/components/pages/myPage/ReservationList/reservationContent';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { useDeviceState } from '@/hooks/useDeviceState';
 import { modalAtom } from '@/store/modalAtom';
 import { Device } from '@/types/deviceTypes';
 import { useAtom } from 'jotai';
-import { useEffect } from 'react';
 
 const ReservationList = () => {
   const [modalType, setModalType] = useAtom(modalAtom);
@@ -30,30 +28,6 @@ const ReservationList = () => {
   const handleCloseModal = () => {
     setModalType(null);
   };
-
-  const modalRef = useClickOutside(handleCloseModal);
-
-  const getScrollbarWidth = () => {
-    return window.innerWidth - document.documentElement.clientWidth;
-  };
-
-  useEffect(() => {
-    const scrollbarWidth = getScrollbarWidth();
-
-    // 모달 열려있는 경우 스크롤바 숨기는 로직
-    if (modalType) {
-      document.body.style.overflow = 'hidden';
-      document.body.style.paddingRight = `${scrollbarWidth}px`;
-    } else {
-      document.body.style.overflow = 'auto';
-      document.body.style.paddingRight = '0px';
-    }
-
-    return () => {
-      document.body.style.overflow = 'auto';
-      document.body.style.paddingRight = '0px';
-    };
-  }, [modalType]);
 
   return (
     <>
@@ -84,28 +58,20 @@ const ReservationList = () => {
             </div>
           </div>
         )}
-        {modalType === 'cancel' && (
-          <Modal.Overlay>
-            <div ref={modalRef}>
-              <Modal.CancelConfirm />
-            </div>
-          </Modal.Overlay>
-        )}
-        {modalType === 'review' && (
-          <Modal.Overlay>
-            <div ref={modalRef} className="h-full w-full md:h-auto md:w-auto">
-              <Modal.Review
-                title="함께 배우면 즐거운 스트릿 댄스"
-                bannerImageUrl="/images/test-profile-img.png"
-                date="2023. 2. 14"
-                startTime="11:00"
-                endTime="12:30"
-                totalPrice={10000}
-                headCount={10}
-              />
-            </div>
-          </Modal.Overlay>
-        )}
+        <Modal.Overlay isOpen={modalType !== null} onClose={handleCloseModal}>
+          {modalType === 'cancel' && <Modal.CancelConfirm />}
+          {modalType === 'review' && (
+            <Modal.Review
+              title="함께 배우면 즐거운 스트릿 댄스"
+              bannerImageUrl="/images/test-profile-img.png"
+              date="2023. 2. 14"
+              startTime="11:00"
+              endTime="12:30"
+              totalPrice={10000}
+              headCount={10}
+            />
+          )}
+        </Modal.Overlay>
         <div ref={setTarget}></div>
       </main>
       <Footer />

--- a/src/pages/my-page/reservation-list.tsx
+++ b/src/pages/my-page/reservation-list.tsx
@@ -32,8 +32,8 @@ const ReservationList = () => {
   return (
     <>
       <NavBar />
-      {queryError && <div className="mb-4 text-red-500">{queryError.message}</div>}
-      <main className="mx-auto mb-94 mt-94 w-344 md:w-696 lg:mb-142 lg:mt-142 lg:w-1200">
+      <main className="md:mb-400 lg:mb-270 mx-auto mb-[496px] mt-94 w-344 md:w-696 lg:mb-142 lg:mt-142 lg:w-1200">
+        {queryError && <div className="mb-4 text-red-500">{queryError.message}</div>}
         {isMobile && (
           <div>
             <ReservationContent

--- a/src/pages/my-page/schedule.tsx
+++ b/src/pages/my-page/schedule.tsx
@@ -1,3 +1,5 @@
+import Footer from '@/components/common/Footer';
+import NavBar from '@/components/common/NavBar';
 import SideNavMenu from '@/components/common/SideNavMenu';
 import MySchedule from '@/components/pages/myPage/Schedule/mySchedule';
 import useViewportSize from '@/hooks/useViewportSize';
@@ -8,20 +10,18 @@ const Schedule = () => {
 
   return (
     <div>
-      <div className="bg-gray-100">
-        <div className="ml-auto mr-auto flex md:w-744 lg:w-1200">
-          <div className="ml-30 mt-30">
-            {isSideNavbarOpen && (
-              <div className="hidden w-60 bg-white md:block">
-                <SideNavMenu />
-              </div>
-            )}
+      <NavBar />
+      <div className="ml-auto mr-auto mt-94 flex w-343 md:w-696 lg:mt-142 lg:w-1200">
+        {isSideNavbarOpen && (
+          <div className="hidden w-60 bg-white md:block">
+            <SideNavMenu />
           </div>
-          <div className="mb-60 ml-auto mr-auto w-343 md:mr-0 md:w-430 lg:w-750">
-            <MySchedule />
-          </div>
+        )}
+        <div className="mb-60 ml-auto mr-auto md:mr-0 md:w-430 lg:w-792">
+          <MySchedule />
         </div>
       </div>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/social/google.tsx
+++ b/src/pages/social/google.tsx
@@ -2,7 +2,6 @@ import Modal from '@/components/common/Modal';
 import { useGoogleAuth } from '@/components/pages/auth/useGoogleAuth';
 import ErrorMessages from '@/constants/errorMessages';
 import SuccessMessages from '@/constants/successMessages';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { useToggle } from '@/hooks/useToggle';
 import { useRouter } from 'next/router';
 
@@ -21,28 +20,22 @@ const GoogleAuthPage = () => {
     }
   };
 
-  const modalRef = useClickOutside(handleModalClose);
-
   return (
     <>
-      {isModalOpen && (
-        <Modal.Overlay>
-          <div ref={modalRef}>
-            <Modal.RegisterConfirm onClose={handleModalClose}>
-              {isLoading ? (
-                <p>Google 계정으로 로그인 중...</p>
-              ) : isSuccess ? (
-                SuccessMessages.SIGNIN_SUCCESS
-              ) : error ? (
-                <div className="flex flex-col items-center">
-                  <p className="mb-4 text-red-200">{ErrorMessages.SIGNIN_ERROR}</p>
-                  <p>로그인을 다시 시도해주세요.</p>
-                </div>
-              ) : null}
-            </Modal.RegisterConfirm>
-          </div>
-        </Modal.Overlay>
-      )}
+      <Modal.Overlay onClose={handleModalClose} isOpen={isModalOpen}>
+        <Modal.RegisterConfirm onClose={handleModalClose}>
+          {isLoading ? (
+            <p>Google 계정으로 로그인 중...</p>
+          ) : isSuccess ? (
+            SuccessMessages.SIGNIN_SUCCESS
+          ) : error ? (
+            <div className="flex flex-col items-center">
+              <p className="mb-4 text-red-200">{ErrorMessages.SIGNIN_ERROR}</p>
+              <p>로그인을 다시 시도해주세요.</p>
+            </div>
+          ) : null}
+        </Modal.RegisterConfirm>
+      </Modal.Overlay>
     </>
   );
 };

--- a/src/pages/social/kakao.tsx
+++ b/src/pages/social/kakao.tsx
@@ -2,7 +2,6 @@ import Modal from '@/components/common/Modal';
 import { useKakaoAuth } from '@/components/pages/auth/useKakaoAuth';
 import ErrorMessages from '@/constants/errorMessages';
 import SuccessMessages from '@/constants/successMessages';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { useToggle } from '@/hooks/useToggle';
 import { useRouter } from 'next/router';
 
@@ -21,28 +20,22 @@ const KakaoAuthPage = () => {
     }
   };
 
-  const modalRef = useClickOutside(handleModalClose);
-
   return (
     <>
-      {isModalOpen && (
-        <Modal.Overlay>
-          <div ref={modalRef}>
-            <Modal.RegisterConfirm onClose={handleModalClose}>
-              {isLoading ? (
-                <p>카카오 계정으로 로그인 중...</p>
-              ) : isSuccess ? (
-                SuccessMessages.SIGNIN_SUCCESS
-              ) : error ? (
-                <div className="flex flex-col items-center">
-                  <p className="mb-4 text-red-200">{ErrorMessages.SIGNIN_ERROR}</p>
-                  <p>로그인을 다시 시도해주세요.</p>
-                </div>
-              ) : null}
-            </Modal.RegisterConfirm>
-          </div>
-        </Modal.Overlay>
-      )}
+      <Modal.Overlay isOpen={isModalOpen} onClose={handleModalClose}>
+        <Modal.RegisterConfirm onClose={handleModalClose}>
+          {isLoading ? (
+            <p>카카오 계정으로 로그인 중...</p>
+          ) : isSuccess ? (
+            SuccessMessages.SIGNIN_SUCCESS
+          ) : error ? (
+            <div className="flex flex-col items-center">
+              <p className="mb-4 text-red-200">{ErrorMessages.SIGNIN_ERROR}</p>
+              <p>로그인을 다시 시도해주세요.</p>
+            </div>
+          ) : null}
+        </Modal.RegisterConfirm>
+      </Modal.Overlay>
     </>
   );
 };

--- a/src/store/toastsAtom.ts
+++ b/src/store/toastsAtom.ts
@@ -1,0 +1,23 @@
+import { ToastProps, ToastType } from '@/components/common/Toast';
+import { atom } from 'jotai';
+
+export const toastsAtom = atom<ToastProps[]>([]);
+
+export const toastAtom = atom(null, (get, set, type: ToastType) => (message: string) => {
+  const prevAtom = get(toastsAtom);
+  const newToast = {
+    type,
+    message,
+    id: Date.now().toString(),
+  };
+
+  set(toastsAtom, [...prevAtom, newToast]);
+});
+
+export const removeToastAtom = atom(null, (get, set, id: string) => {
+  const prevAtom = get(toastsAtom);
+  set(
+    toastsAtom,
+    prevAtom.filter((toast) => toast.id !== id),
+  );
+});

--- a/src/stories/Toast/toast.stories.tsx
+++ b/src/stories/Toast/toast.stories.tsx
@@ -1,0 +1,49 @@
+import Toast, { ToastProps } from '@/components/common/Toast';
+import { useToggle } from '@/hooks/useToggle';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ComponentProps, useEffect } from 'react';
+
+type StoryProps = ComponentProps<typeof Toast>;
+
+const meta: Meta<typeof Toast> = {
+  component: Toast,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<StoryProps>;
+
+const ShowToastButton = (args: ToastProps) => {
+  const { current: showToast, handleToggle: toggleToast } = useToggle(false);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+
+    if (showToast) {
+      timer = setTimeout(() => {
+        toggleToast();
+      }, 3000);
+    }
+
+    return () => clearTimeout(timer);
+  }, [showToast, toggleToast]);
+
+  return (
+    <div>
+      <button onClick={toggleToast} className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600">
+        Show Toast
+      </button>
+      {showToast && <Toast {...args} />}
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: (args) => <ShowToastButton {...args} />,
+  args: {
+    type: 'success',
+    message: '토스트가 성공적으로 띄워졌습니다!',
+    id: '1',
+  },
+};

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -61,6 +61,6 @@ export const registActivitySchema = yup.object().shape({
         return value.startsWith('data:image/') || value.startsWith('blob:') || /\.(jpg|jpeg|png|gif)$/i.test(value);
       }),
     )
-    .min(1, REGIST_ACTIVITY_ERROR_MESSAGES.INTRO_IMAGES_REQUIRED)
+    .test('is-exactly-four', REGIST_ACTIVITY_ERROR_MESSAGES.INTRO_IMAGES_REQUIRED, (value) => value?.length === 4)
     .required(REGIST_ACTIVITY_ERROR_MESSAGES.INTRO_IMAGES_REQUIRED),
 });


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

FP-85 

## ✅ 작업 사항
### 1. 프레이머 모션 적용
AnimatedContainer 공통 컴포넌트를 생성하여 프레이머 모션을 적용했습니다. 사용 방법은 아래와 같이 모션을 사용할 컴포넌트를 감싸주시면 됩니다.

```
<AnimatedContainer>
  <ExampleComponent />
</AnimatedContainer>
```

### 2. 토스트로 에러 띄우기
커스텀 Toast 컴포넌트를 생성했습니다. 사용 방법은 아래와 같습니다.

```
import useToast from '@/hooks/useToast';
const toast = useToast();

useEffect(() => {
    if (error) {
      if (isAxiosError(error)) {
        if (error.response?.status === 401) {
          toast.error('인증에 실패했습니다. 다시 로그인해주세요.');
        } else {
          toast.error(error.message || '예약 정보를 불러오는 데 실패했습니다.');
        }
      } else {
        toast.error('알 수 없는 오류가 발생했습니다.');
      }
    }
  }, [error, toast]);
  ```
  
동작 화면은 아래와 같습니다.
![스크린샷 2024-08-22 223158](https://github.com/user-attachments/assets/b84baac3-88b0-491b-9a75-d3e4348a29b3)


에러 메세지를 띄우고 싶은 경우는 **toast.error('에러 메세지')**를 작성하시면 됩니다. 
성공 메세지를 띄우고 싶으신 경우 **toast.success('성공 메세지')**를 작성하시면 됩니다.

### 3. ModalOverlay 컴포넌트의 React 관련 타입을 단일 임포트로 통합
```
<Modal.Overlay>
  <div ref={modalRef}>
    <Modal.RegisterConfirm onClose={handleCloseModal}>
       체험 등록이 완료되었습니다.
     </Modal.RegisterConfirm>
  </div>
</Modal.Overlay>
```
위의 코드를 다음과 같이 간결하게 작성하도록 로직을 수정했습니다. 

```
<Modal.Overlay isOpen={isModalOpen} onClose={handleCloseModal}>
  <Modal.RegisterConfirm onClose={handleCloseModal}>
    체험 등록이 완료되었습니다.
  </Modal.RegisterConfirm>
</Modal.Overlay>
```
### 4. 마이페이지 전체적인 레이아웃 통일
마이페이지 내의 margin이나 padding을 일관되게 작성하여 레이아웃을 통일시켰습니다.

## 👩‍💻 공유 포인트 및 논의 사항
- 경원님 프레이머 모션에 대해 위에 작성해두었습니다! 추가적인 질문있으시면 말씀부탁드려요~~!
- 에러 또는 성공 메세지 처리를 일괄적으로 진행하면 좋을 것 같은데, 제가 구현한 커스텀 토스트로 처리하는 것 괜찮으신지 여쭤보고 싶습니다!😊