### PR TITLE
Refactor: 체험 상세 페이지 수정사항 반영 및 리팩토링

### DIFF
--- a/src/components/pages/ActivityDetails/activityInformation.tsx
+++ b/src/components/pages/ActivityDetails/activityInformation.tsx
@@ -127,7 +127,7 @@ const ActivityInformation = ({
             </Modal.RegisterConfirm>
           </Modal.Overlay>
         )}
-        <div className="fixed bottom-170 right-10 flex lg:sticky lg:bottom-0 lg:right-0 lg:mb-20 lg:justify-end">
+        <div className="fixed bottom-170 right-10 flex lg:sticky lg:bottom-30 lg:right-0 lg:mb-20 lg:justify-end">
           <ScrollToTopButton />
         </div>
       </div>

--- a/src/components/pages/ActivityDetails/description.tsx
+++ b/src/components/pages/ActivityDetails/description.tsx
@@ -15,40 +15,33 @@ const Description = ({ description }: { description: string }) => {
   };
 
   const renderDescription = (text: string) => {
-    const paragraphs = text.split('\n\n');
-    return paragraphs.map((paragraph, index) => (
-      <p key={index} className="mb-4 whitespace-pre-line text-lg-regular text-black-100 last:mb-0">
-        {paragraph}
-      </p>
-    ));
+    return <pre className="whitespace-pre-wrap break-words font-sans text-16 leading-relaxed">{text}</pre>;
   };
 
+  const truncatedDescription = description.slice(0, maxLength);
+  const remainingDescription = description.slice(maxLength);
+
   return (
-    <div className="flex flex-col border-b border-solid border-gray-300 py-16 md:border-t md:py-40">
-      <h1 className="text-xl-bold text-black-100">체험 설명</h1>
-      <div className="mt-16">
-        {renderDescription(isExpanded ? description : description.slice(0, maxLength))}
-        {!isExpanded && description.length > maxLength && '...'}
-      </div>
-      <AnimatePresence initial={false}>
+    <div className="mb-32 md:mb-40">
+      <h2 className="mb-16 text-20 font-bold md:text-24">체험 설명</h2>
+      {renderDescription(truncatedDescription)}
+      {!isExpanded && description.length > maxLength && '...'}
+      <AnimatePresence>
         {isExpanded && description.length > maxLength && (
           <motion.div
             initial="hidden"
             animate="visible"
             exit="hidden"
             variants={variants}
-            transition={{ duration: 0.2 }}
+            transition={{ duration: 0.3 }}
           >
-            {renderDescription(description.slice(maxLength))}
+            {renderDescription(remainingDescription)}
           </motion.div>
         )}
       </AnimatePresence>
       {description.length > maxLength && (
-        <button
-          onClick={toggleExpand}
-          className="mt-16 cursor-pointer self-start text-lg-bold text-blue-200 hover:text-blue-300"
-        >
-          {isExpanded ? <a href="#title">접기</a> : '더보기'}
+        <button onClick={toggleExpand} className="mt-8 text-16 text-blue-500 hover:underline">
+          {isExpanded ? '접기' : '더보기'}
         </button>
       )}
     </div>

--- a/src/components/pages/ActivityDetails/scrollToTopButton.tsx
+++ b/src/components/pages/ActivityDetails/scrollToTopButton.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, animate, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
+import { IoIosArrowRoundUp } from 'react-icons/io';
 
 const ScrollToTopButton = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -38,7 +39,7 @@ const ScrollToTopButton = () => {
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9 }}
         >
-          ↑
+          <IoIosArrowRoundUp size={28} />
         </motion.button>
       )}
     </AnimatePresence>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

- FP-110

## ✅ 작업 사항
- 우측 하단에 페이지 최상단으로 가는 버튼 화살표를 텍스트에서 React Icon 사용하여 이미지로 변환
- 체험 설명이 두번씩 반복되는 현상 수정(데이터는 체험 등록 했을 때 내용으로 잘 받아오는데 화면에 렌더링하는 로직에서 문제 있었던거였으)

## 👩‍💻 공유 포인트 및 논의 사항
