### PR TITLE
Refactor: 체험 상세 페이지 이미지 모달 열려 있을 때 스크롤 방지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-icons": "^5.3.0",
         "react-kakao-maps-sdk": "^1.1.27",
         "react-swipeable": "^7.0.1",
+        "swiper": "^11.1.14",
         "tailwind-scrollbar-hide": "^1.1.7",
         "webpack": "^5.93.0",
         "yup": "^1.4.0"
@@ -16643,6 +16644,25 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.1.14",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.14.tgz",
+      "integrity": "sha512-VbQLQXC04io6AoAjIUWuZwW4MSYozkcP9KjLdrsG/00Q/yiwvhz9RQyt0nHXV10hi9NVnDNy1/wv7Dzq1lkOCQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/synckit": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-icons": "^5.3.0",
     "react-kakao-maps-sdk": "^1.1.27",
     "react-swipeable": "^7.0.1",
+    "swiper": "^11.1.14",
     "tailwind-scrollbar-hide": "^1.1.7",
     "webpack": "^5.93.0",
     "yup": "^1.4.0"

--- a/src/components/pages/ActivityDetails/activityInformation.tsx
+++ b/src/components/pages/ActivityDetails/activityInformation.tsx
@@ -127,7 +127,7 @@ const ActivityInformation = ({
             </Modal.RegisterConfirm>
           </Modal.Overlay>
         )}
-        <div className="fixed bottom-170 right-10 flex lg:sticky lg:bottom-0 lg:right-0 lg:mb-20 lg:justify-end">
+        <div className="fixed bottom-170 right-10 flex lg:sticky lg:bottom-30 lg:right-0 lg:mb-20 lg:justify-end">
           <ScrollToTopButton />
         </div>
       </div>

--- a/src/components/pages/ActivityDetails/bannerImage.tsx
+++ b/src/components/pages/ActivityDetails/bannerImage.tsx
@@ -1,7 +1,7 @@
 import useViewportSize from '@/hooks/useViewportSize';
 import { SubImage } from '@/types/activity';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import BannerImageModal from './bannerImageModal';
 
@@ -26,6 +26,19 @@ const BannerImage = ({ bannerImageUrl, subImages }: { bannerImageUrl: string; su
   const goToNextImage = () => {
     setCurrentImageIndex((prevIndex) => (prevIndex === allImages.length - 1 ? 0 : prevIndex + 1));
   };
+
+  // 모달 열렸을때 스크롤 방지
+  useEffect(() => {
+    if (isModalOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, [isModalOpen]);
 
   return (
     <>

--- a/src/components/pages/ActivityDetails/description.tsx
+++ b/src/components/pages/ActivityDetails/description.tsx
@@ -15,40 +15,33 @@ const Description = ({ description }: { description: string }) => {
   };
 
   const renderDescription = (text: string) => {
-    const paragraphs = text.split('\n\n');
-    return paragraphs.map((paragraph, index) => (
-      <p key={index} className="mb-4 whitespace-pre-line text-lg-regular text-black-100 last:mb-0">
-        {paragraph}
-      </p>
-    ));
+    return <pre className="whitespace-pre-wrap break-words font-sans text-16 leading-relaxed">{text}</pre>;
   };
 
+  const truncatedDescription = description.slice(0, maxLength);
+  const remainingDescription = description.slice(maxLength);
+
   return (
-    <div className="flex flex-col border-b border-solid border-gray-300 py-16 md:border-t md:py-40">
-      <h1 className="text-xl-bold text-black-100">체험 설명</h1>
-      <div className="mt-16">
-        {renderDescription(isExpanded ? description : description.slice(0, maxLength))}
-        {!isExpanded && description.length > maxLength && '...'}
-      </div>
-      <AnimatePresence initial={false}>
+    <div className="mb-32 md:mb-40">
+      <h2 className="mb-16 text-20 font-bold md:text-24">체험 설명</h2>
+      {renderDescription(truncatedDescription)}
+      {!isExpanded && description.length > maxLength && '...'}
+      <AnimatePresence>
         {isExpanded && description.length > maxLength && (
           <motion.div
             initial="hidden"
             animate="visible"
             exit="hidden"
             variants={variants}
-            transition={{ duration: 0.2 }}
+            transition={{ duration: 0.3 }}
           >
-            {renderDescription(description.slice(maxLength))}
+            {renderDescription(remainingDescription)}
           </motion.div>
         )}
       </AnimatePresence>
       {description.length > maxLength && (
-        <button
-          onClick={toggleExpand}
-          className="mt-16 cursor-pointer self-start text-lg-bold text-blue-200 hover:text-blue-300"
-        >
-          {isExpanded ? <a href="#title">접기</a> : '더보기'}
+        <button onClick={toggleExpand} className="mt-8 text-16 text-blue-500 hover:underline">
+          {isExpanded ? '접기' : '더보기'}
         </button>
       )}
     </div>

--- a/src/components/pages/ActivityDetails/scrollToTopButton.tsx
+++ b/src/components/pages/ActivityDetails/scrollToTopButton.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, animate, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
+import { IoIosArrowRoundUp } from 'react-icons/io';
 
 const ScrollToTopButton = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -38,7 +39,7 @@ const ScrollToTopButton = () => {
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9 }}
         >
-          ↑
+          <IoIosArrowRoundUp size={28} />
         </motion.button>
       )}
     </AnimatePresence>


### PR DESCRIPTION
## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

- FP-110

## ✅ 작업 사항
- 체험 상세 페이지 이미지 모달이 열려 있을 때 스크롤 방지하도록 변경했습니다!


## 👩‍💻 공유 포인트 및 논의 사항
- 스와이프 기능 구현을 위해서 swiper 라이브러리 설치했습니다 npm i 하고 작업해주세요~!